### PR TITLE
Untitled

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1,0 +1,113 @@
+# Cassandra YAML generated from previous config
+# Configuration wiki: http://wiki.apache.org/cassandra/StorageConfiguration
+
+cluster_name:                        Test
+
+listen_address:                      localhost
+storage_port:                        7000
+rpc_port:                            9160
+seeds:
+  - 127.0.0.1
+data_file_directories:
+  - data/cassandra/data
+commitlog_directory:                 data/cassandra/commitlog
+auto_bootstrap:                      false
+partitioner:                         org.apache.cassandra.dht.RandomPartitioner
+authenticator:                       org.apache.cassandra.auth.AllowAllAuthenticator
+
+binary_memtable_throughput_in_mb:    256
+column_index_size_in_kb:             64
+commitlog_rotation_threshold_in_mb:  128
+commitlog_sync:                      periodic
+commitlog_sync_period_in_ms:         10000
+concurrent_reads:                    8
+concurrent_writes:                   32
+disk_access_mode:                    auto
+dynamic_snitch:                      false
+hinted_handoff_enabled:              true
+in_memory_compaction_limit_in_mb:    256
+memtable_flush_after_mins:           60
+memtable_operations_in_millions:     0.3
+memtable_throughput_in_mb:           64
+phi_convict_threshold:               8
+rpc_timeout_in_ms:                   5000
+sliced_buffer_size_in_kb:            64
+snapshot_before_compaction:          false
+thrift_framed_transport_size_in_mb:  15
+thrift_max_message_length_in_mb:     16
+
+
+keyspaces:
+
+    - name: Twitter
+      replication_factor: 1
+      replica_placement_strategy: org.apache.cassandra.locator.RackUnawareStrategy
+      column_families:
+      - name:                    Users
+        compare_with:            UTF8Type
+      - name:                    UserAudits
+        compare_with:            UTF8Type
+      - name:                    UserRelationships
+        compare_with:            UTF8Type
+        column_type:             Super
+        compare_subcolumns_with: TimeUUIDType
+      - name:                    Usernames
+        compare_with:            UTF8Type
+      - name:                    Statuses
+        compare_with:            UTF8Type
+      - name:                    StatusAudits
+        compare_with:            UTF8Type
+      - name:                    StatusRelationships
+        compare_with:            UTF8Type
+        column_type:             Super
+        compare_subcolumns_with: TimeUUIDType
+      - name:                    Index
+        compare_with:            UTF8Type
+        column_type:             Super
+      - name:                    TimelinishThings
+        compare_with:            BytesType
+        column_type:             Standard
+
+    - name: Multiblog
+      replication_factor: 1
+      replica_placement_strategy: org.apache.cassandra.locator.RackUnawareStrategy
+      column_families:
+      - name:                    Blogs
+        compare_with:            TimeUUIDType
+      - name:                    Comments
+        compare_with:            TimeUUIDType
+
+    - name: MultiblogLong
+      replication_factor: 1
+      replica_placement_strategy: org.apache.cassandra.locator.RackUnawareStrategy
+      column_families:
+      - name:                    Blogs
+        compare_with:            LongType
+      - name:                    Comments
+        compare_with:            LongType
+
+    - name: CassandraObject
+      replication_factor: 1
+      replica_placement_strategy: org.apache.cassandra.locator.RackUnawareStrategy
+      column_families:
+      - name:                    Customers
+        compare_with:            UTF8Type
+      - name:                    CustomerRelationships
+        compare_with:            UTF8Type
+        column_type:             Super
+        compare_subcolumns_with: TimeUUIDType
+      - name:                    CustomersByLastName
+        compare_with:            TimeUUIDType
+      - name:                    Invoices
+        compare_with:            UTF8Type
+      - name:                    InvoiceRelationships
+        compare_with:            UTF8Type
+        column_type:             Super
+        compare_subcolumns_with: TimeUUIDType
+      - name:                    InvoicesByNumber
+        compare_with:            UTF8Type
+      - name:                    Payments
+        compare_with:            UTF8Type
+      - name:                    Appointments
+        compare_with:            UTF8Type
+  

--- a/lib/cassandra/0.7/protocol.rb
+++ b/lib/cassandra/0.7/protocol.rb
@@ -46,21 +46,24 @@ class Cassandra
     def _multiget(column_family, keys, column, sub_column, count, start, finish, reversed, consistency)
       # Single values; count and range parameters have no effect
       if is_super(column_family) and sub_column
-        column_path = CassandraThrift::ColumnPath.new(:column_family => column_family, :super_column => column, :column => sub_column)
-        multi_column_to_hash!(client.multiget(keys, column_path, consistency))
+        predicate = CassandraThrift::SlicePredicate.new(:column_names => [column])
+        column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family, :super_column => column)
+        multi_sub_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
+
       elsif !is_super(column_family) and column
-        column_path = CassandraThrift::ColumnPath.new(:column_family => column_family, :column => column)
-        multi_column_to_hash!(client.multiget(keys, column_path, consistency))
+        predicate = CassandraThrift::SlicePredicate.new(:column_names => [column])
+        column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family)
+        multi_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
 
       # Slices
       else
-        predicate = CassandraThrift::SlicePredicate.new(:slice_range => 
+        predicate = CassandraThrift::SlicePredicate.new(:slice_range =>
           CassandraThrift::SliceRange.new(
-            :reversed => reversed, 
-            :count => count, 
-            :start => start, 
+            :reversed => reversed,
+            :count => count,
+            :start => start,
             :finish => finish))
-        
+
         if is_super(column_family) and column
           column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family, :super_column => column)
           multi_sub_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
@@ -77,7 +80,7 @@ class Cassandra
       range = CassandraThrift::KeyRange.new(:start_key => start, :end_key => finish, :count => count)
       client.get_range_slices(column_parent, predicate, range, 1)
     end
-    
+
     def _get_range_keys(column_family, start, finish, count, consistency)
       _get_range(column_family, start, finish, count, consistency).collect{|i| i.key }
     end


### PR DESCRIPTION
The _multiget method in 0.7/protocol refers to the now-removed multiget API call.
Changed it to call multiget_slice in a way that is hopefully compatible.

Also, converted the storage-conf.xml to a v0.7 cassandra.yaml
