### PR TITLE
Updated thrift bindings for cassandra 0.7rc1

### DIFF
--- a/lib/cassandra.rb
+++ b/lib/cassandra.rb
@@ -1,5 +1,10 @@
 require 'rubygems'
-gem 'thrift', '< 0.2.5'
+if Cassandra.VERSION.eql?("0.6")
+  gem 'thrift', '< 0.2.5'
+else
+  gem 'thrift', '>= 0.5.0'
+  gem 'thrift_client', '>= 0.5'
+end
 require 'thrift'
 require 'thrift_client'
 require 'json' unless defined?(JSON)

--- a/lib/cassandra/0.7/cassandra.rb
+++ b/lib/cassandra/0.7/cassandra.rb
@@ -89,16 +89,6 @@ class Cassandra
     res
   end
 
-  def rename_column_family(old_name, new_name)
-    begin
-      res = client.system_rename_column_family(old_name, new_name)
-    rescue CassandraThrift::TimedOutException => te
-      puts "Timed out: #{te.inspect}"
-    end
-    @schema = nil
-    res
-  end
-
   def add_keyspace(ks_def)
     begin
       res = client.system_add_keyspace(ks_def)
@@ -120,19 +110,6 @@ class Cassandra
       puts "Timed out: #{te.inspect}"
     end
     keyspace = "system" if ks_name.eql?(@keyspace)
-    @keyspaces = nil
-    res
-  end
-
-  def rename_keyspace(old_name, new_name)
-    begin
-      res = client.system_rename_keyspace(old_name, new_name)
-    rescue CassandraThrift::TimedOutException => toe
-      puts "Timed out: #{toe.inspect}"
-    rescue Thrift::TransportException => te
-      puts "Timed out: #{te.inspect}"
-    end
-    keyspace = new_name if old_name.eql?(@keyspace)
     @keyspaces = nil
     res
   end

--- a/vendor/0.7/gen-rb/cassandra.rb
+++ b/vendor/0.7/gen-rb/cassandra.rb
@@ -819,10 +819,9 @@ require 'cassandra_types'
         # HELPER FUNCTIONS AND STRUCTURES
 
         class Login_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           AUTH_REQUEST = 1
 
-          ::Thrift::Struct.field_accessor self, :auth_request
           FIELDS = {
             AUTH_REQUEST => {:type => ::Thrift::Types::STRUCT, :name => 'auth_request', :class => CassandraThrift::AuthenticationRequest}
           }
@@ -833,14 +832,14 @@ require 'cassandra_types'
             raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field auth_request is unset!') unless @auth_request
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Login_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           AUTHNX = 1
           AUTHZX = 2
 
-          ::Thrift::Struct.field_accessor self, :authnx, :authzx
           FIELDS = {
             AUTHNX => {:type => ::Thrift::Types::STRUCT, :name => 'authnx', :class => CassandraThrift::AuthenticationException},
             AUTHZX => {:type => ::Thrift::Types::STRUCT, :name => 'authzx', :class => CassandraThrift::AuthorizationException}
@@ -851,13 +850,13 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Set_keyspace_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           KEYSPACE = 1
 
-          ::Thrift::Struct.field_accessor self, :keyspace
           FIELDS = {
             KEYSPACE => {:type => ::Thrift::Types::STRING, :name => 'keyspace'}
           }
@@ -868,13 +867,13 @@ require 'cassandra_types'
             raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field keyspace is unset!') unless @keyspace
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Set_keyspace_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           IRE = 1
 
-          ::Thrift::Struct.field_accessor self, :ire
           FIELDS = {
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException}
           }
@@ -884,17 +883,17 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Get_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           KEY = 1
           COLUMN_PATH = 2
           CONSISTENCY_LEVEL = 3
 
-          ::Thrift::Struct.field_accessor self, :key, :column_path, :consistency_level
           FIELDS = {
-            KEY => {:type => ::Thrift::Types::STRING, :name => 'key'},
+            KEY => {:type => ::Thrift::Types::STRING, :name => 'key', :binary => true},
             COLUMN_PATH => {:type => ::Thrift::Types::STRUCT, :name => 'column_path', :class => CassandraThrift::ColumnPath},
             CONSISTENCY_LEVEL => {:type => ::Thrift::Types::I32, :name => 'consistency_level', :default =>             1, :enum_class => CassandraThrift::ConsistencyLevel}
           }
@@ -910,17 +909,17 @@ require 'cassandra_types'
             end
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Get_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
           NFE = 2
           UE = 3
           TE = 4
 
-          ::Thrift::Struct.field_accessor self, :success, :ire, :nfe, :ue, :te
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::STRUCT, :name => 'success', :class => CassandraThrift::ColumnOrSuperColumn},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException},
@@ -934,18 +933,18 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Get_slice_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           KEY = 1
           COLUMN_PARENT = 2
           PREDICATE = 3
           CONSISTENCY_LEVEL = 4
 
-          ::Thrift::Struct.field_accessor self, :key, :column_parent, :predicate, :consistency_level
           FIELDS = {
-            KEY => {:type => ::Thrift::Types::STRING, :name => 'key'},
+            KEY => {:type => ::Thrift::Types::STRING, :name => 'key', :binary => true},
             COLUMN_PARENT => {:type => ::Thrift::Types::STRUCT, :name => 'column_parent', :class => CassandraThrift::ColumnParent},
             PREDICATE => {:type => ::Thrift::Types::STRUCT, :name => 'predicate', :class => CassandraThrift::SlicePredicate},
             CONSISTENCY_LEVEL => {:type => ::Thrift::Types::I32, :name => 'consistency_level', :default =>             1, :enum_class => CassandraThrift::ConsistencyLevel}
@@ -963,16 +962,16 @@ require 'cassandra_types'
             end
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Get_slice_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
           UE = 2
           TE = 3
 
-          ::Thrift::Struct.field_accessor self, :success, :ire, :ue, :te
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::LIST, :name => 'success', :element => {:type => ::Thrift::Types::STRUCT, :class => CassandraThrift::ColumnOrSuperColumn}},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException},
@@ -985,18 +984,18 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Get_count_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           KEY = 1
           COLUMN_PARENT = 2
           PREDICATE = 3
           CONSISTENCY_LEVEL = 4
 
-          ::Thrift::Struct.field_accessor self, :key, :column_parent, :predicate, :consistency_level
           FIELDS = {
-            KEY => {:type => ::Thrift::Types::STRING, :name => 'key'},
+            KEY => {:type => ::Thrift::Types::STRING, :name => 'key', :binary => true},
             COLUMN_PARENT => {:type => ::Thrift::Types::STRUCT, :name => 'column_parent', :class => CassandraThrift::ColumnParent},
             PREDICATE => {:type => ::Thrift::Types::STRUCT, :name => 'predicate', :class => CassandraThrift::SlicePredicate},
             CONSISTENCY_LEVEL => {:type => ::Thrift::Types::I32, :name => 'consistency_level', :default =>             1, :enum_class => CassandraThrift::ConsistencyLevel}
@@ -1014,16 +1013,16 @@ require 'cassandra_types'
             end
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Get_count_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
           UE = 2
           TE = 3
 
-          ::Thrift::Struct.field_accessor self, :success, :ire, :ue, :te
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::I32, :name => 'success'},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException},
@@ -1036,18 +1035,18 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Multiget_slice_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           KEYS = 1
           COLUMN_PARENT = 2
           PREDICATE = 3
           CONSISTENCY_LEVEL = 4
 
-          ::Thrift::Struct.field_accessor self, :keys, :column_parent, :predicate, :consistency_level
           FIELDS = {
-            KEYS => {:type => ::Thrift::Types::LIST, :name => 'keys', :element => {:type => ::Thrift::Types::STRING}},
+            KEYS => {:type => ::Thrift::Types::LIST, :name => 'keys', :element => {:type => ::Thrift::Types::STRING, :binary => true}},
             COLUMN_PARENT => {:type => ::Thrift::Types::STRUCT, :name => 'column_parent', :class => CassandraThrift::ColumnParent},
             PREDICATE => {:type => ::Thrift::Types::STRUCT, :name => 'predicate', :class => CassandraThrift::SlicePredicate},
             CONSISTENCY_LEVEL => {:type => ::Thrift::Types::I32, :name => 'consistency_level', :default =>             1, :enum_class => CassandraThrift::ConsistencyLevel}
@@ -1065,18 +1064,18 @@ require 'cassandra_types'
             end
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Multiget_slice_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
           UE = 2
           TE = 3
 
-          ::Thrift::Struct.field_accessor self, :success, :ire, :ue, :te
           FIELDS = {
-            SUCCESS => {:type => ::Thrift::Types::MAP, :name => 'success', :key => {:type => ::Thrift::Types::STRING}, :value => {:type => ::Thrift::Types::LIST, :element => {:type => ::Thrift::Types::STRUCT, :class => CassandraThrift::ColumnOrSuperColumn}}},
+            SUCCESS => {:type => ::Thrift::Types::MAP, :name => 'success', :key => {:type => ::Thrift::Types::STRING, :binary => true}, :value => {:type => ::Thrift::Types::LIST, :element => {:type => ::Thrift::Types::STRUCT, :class => CassandraThrift::ColumnOrSuperColumn}}},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException},
             UE => {:type => ::Thrift::Types::STRUCT, :name => 'ue', :class => CassandraThrift::UnavailableException},
             TE => {:type => ::Thrift::Types::STRUCT, :name => 'te', :class => CassandraThrift::TimedOutException}
@@ -1087,18 +1086,18 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Multiget_count_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           KEYS = 1
           COLUMN_PARENT = 2
           PREDICATE = 3
           CONSISTENCY_LEVEL = 4
 
-          ::Thrift::Struct.field_accessor self, :keys, :column_parent, :predicate, :consistency_level
           FIELDS = {
-            KEYS => {:type => ::Thrift::Types::LIST, :name => 'keys', :element => {:type => ::Thrift::Types::STRING}},
+            KEYS => {:type => ::Thrift::Types::LIST, :name => 'keys', :element => {:type => ::Thrift::Types::STRING, :binary => true}},
             COLUMN_PARENT => {:type => ::Thrift::Types::STRUCT, :name => 'column_parent', :class => CassandraThrift::ColumnParent},
             PREDICATE => {:type => ::Thrift::Types::STRUCT, :name => 'predicate', :class => CassandraThrift::SlicePredicate},
             CONSISTENCY_LEVEL => {:type => ::Thrift::Types::I32, :name => 'consistency_level', :default =>             1, :enum_class => CassandraThrift::ConsistencyLevel}
@@ -1116,18 +1115,18 @@ require 'cassandra_types'
             end
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Multiget_count_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
           UE = 2
           TE = 3
 
-          ::Thrift::Struct.field_accessor self, :success, :ire, :ue, :te
           FIELDS = {
-            SUCCESS => {:type => ::Thrift::Types::MAP, :name => 'success', :key => {:type => ::Thrift::Types::STRING}, :value => {:type => ::Thrift::Types::I32}},
+            SUCCESS => {:type => ::Thrift::Types::MAP, :name => 'success', :key => {:type => ::Thrift::Types::STRING, :binary => true}, :value => {:type => ::Thrift::Types::I32}},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException},
             UE => {:type => ::Thrift::Types::STRUCT, :name => 'ue', :class => CassandraThrift::UnavailableException},
             TE => {:type => ::Thrift::Types::STRUCT, :name => 'te', :class => CassandraThrift::TimedOutException}
@@ -1138,16 +1137,16 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Get_range_slices_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           COLUMN_PARENT = 1
           PREDICATE = 2
           RANGE = 3
           CONSISTENCY_LEVEL = 4
 
-          ::Thrift::Struct.field_accessor self, :column_parent, :predicate, :range, :consistency_level
           FIELDS = {
             COLUMN_PARENT => {:type => ::Thrift::Types::STRUCT, :name => 'column_parent', :class => CassandraThrift::ColumnParent},
             PREDICATE => {:type => ::Thrift::Types::STRUCT, :name => 'predicate', :class => CassandraThrift::SlicePredicate},
@@ -1167,16 +1166,16 @@ require 'cassandra_types'
             end
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Get_range_slices_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
           UE = 2
           TE = 3
 
-          ::Thrift::Struct.field_accessor self, :success, :ire, :ue, :te
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::LIST, :name => 'success', :element => {:type => ::Thrift::Types::STRUCT, :class => CassandraThrift::KeySlice}},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException},
@@ -1189,16 +1188,16 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Get_indexed_slices_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           COLUMN_PARENT = 1
           INDEX_CLAUSE = 2
           COLUMN_PREDICATE = 3
           CONSISTENCY_LEVEL = 4
 
-          ::Thrift::Struct.field_accessor self, :column_parent, :index_clause, :column_predicate, :consistency_level
           FIELDS = {
             COLUMN_PARENT => {:type => ::Thrift::Types::STRUCT, :name => 'column_parent', :class => CassandraThrift::ColumnParent},
             INDEX_CLAUSE => {:type => ::Thrift::Types::STRUCT, :name => 'index_clause', :class => CassandraThrift::IndexClause},
@@ -1218,16 +1217,16 @@ require 'cassandra_types'
             end
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Get_indexed_slices_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
           UE = 2
           TE = 3
 
-          ::Thrift::Struct.field_accessor self, :success, :ire, :ue, :te
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::LIST, :name => 'success', :element => {:type => ::Thrift::Types::STRUCT, :class => CassandraThrift::KeySlice}},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException},
@@ -1240,18 +1239,18 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Insert_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           KEY = 1
           COLUMN_PARENT = 2
           COLUMN = 3
           CONSISTENCY_LEVEL = 4
 
-          ::Thrift::Struct.field_accessor self, :key, :column_parent, :column, :consistency_level
           FIELDS = {
-            KEY => {:type => ::Thrift::Types::STRING, :name => 'key'},
+            KEY => {:type => ::Thrift::Types::STRING, :name => 'key', :binary => true},
             COLUMN_PARENT => {:type => ::Thrift::Types::STRUCT, :name => 'column_parent', :class => CassandraThrift::ColumnParent},
             COLUMN => {:type => ::Thrift::Types::STRUCT, :name => 'column', :class => CassandraThrift::Column},
             CONSISTENCY_LEVEL => {:type => ::Thrift::Types::I32, :name => 'consistency_level', :default =>             1, :enum_class => CassandraThrift::ConsistencyLevel}
@@ -1269,15 +1268,15 @@ require 'cassandra_types'
             end
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Insert_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           IRE = 1
           UE = 2
           TE = 3
 
-          ::Thrift::Struct.field_accessor self, :ire, :ue, :te
           FIELDS = {
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException},
             UE => {:type => ::Thrift::Types::STRUCT, :name => 'ue', :class => CassandraThrift::UnavailableException},
@@ -1289,18 +1288,18 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Remove_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           KEY = 1
           COLUMN_PATH = 2
           TIMESTAMP = 3
           CONSISTENCY_LEVEL = 4
 
-          ::Thrift::Struct.field_accessor self, :key, :column_path, :timestamp, :consistency_level
           FIELDS = {
-            KEY => {:type => ::Thrift::Types::STRING, :name => 'key'},
+            KEY => {:type => ::Thrift::Types::STRING, :name => 'key', :binary => true},
             COLUMN_PATH => {:type => ::Thrift::Types::STRUCT, :name => 'column_path', :class => CassandraThrift::ColumnPath},
             TIMESTAMP => {:type => ::Thrift::Types::I64, :name => 'timestamp'},
             CONSISTENCY_LEVEL => {:type => ::Thrift::Types::I32, :name => 'consistency_level', :default =>             1, :enum_class => CassandraThrift::ConsistencyLevel}
@@ -1317,15 +1316,15 @@ require 'cassandra_types'
             end
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Remove_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           IRE = 1
           UE = 2
           TE = 3
 
-          ::Thrift::Struct.field_accessor self, :ire, :ue, :te
           FIELDS = {
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException},
             UE => {:type => ::Thrift::Types::STRUCT, :name => 'ue', :class => CassandraThrift::UnavailableException},
@@ -1337,16 +1336,16 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Batch_mutate_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           MUTATION_MAP = 1
           CONSISTENCY_LEVEL = 2
 
-          ::Thrift::Struct.field_accessor self, :mutation_map, :consistency_level
           FIELDS = {
-            MUTATION_MAP => {:type => ::Thrift::Types::MAP, :name => 'mutation_map', :key => {:type => ::Thrift::Types::STRING}, :value => {:type => ::Thrift::Types::MAP, :key => {:type => ::Thrift::Types::STRING}, :value => {:type => ::Thrift::Types::LIST, :element => {:type => ::Thrift::Types::STRUCT, :class => CassandraThrift::Mutation}}}},
+            MUTATION_MAP => {:type => ::Thrift::Types::MAP, :name => 'mutation_map', :key => {:type => ::Thrift::Types::STRING, :binary => true}, :value => {:type => ::Thrift::Types::MAP, :key => {:type => ::Thrift::Types::STRING}, :value => {:type => ::Thrift::Types::LIST, :element => {:type => ::Thrift::Types::STRUCT, :class => CassandraThrift::Mutation}}}},
             CONSISTENCY_LEVEL => {:type => ::Thrift::Types::I32, :name => 'consistency_level', :default =>             1, :enum_class => CassandraThrift::ConsistencyLevel}
           }
 
@@ -1360,15 +1359,15 @@ require 'cassandra_types'
             end
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Batch_mutate_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           IRE = 1
           UE = 2
           TE = 3
 
-          ::Thrift::Struct.field_accessor self, :ire, :ue, :te
           FIELDS = {
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException},
             UE => {:type => ::Thrift::Types::STRUCT, :name => 'ue', :class => CassandraThrift::UnavailableException},
@@ -1380,13 +1379,13 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Truncate_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           CFNAME = 1
 
-          ::Thrift::Struct.field_accessor self, :cfname
           FIELDS = {
             CFNAME => {:type => ::Thrift::Types::STRING, :name => 'cfname'}
           }
@@ -1397,14 +1396,14 @@ require 'cassandra_types'
             raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field cfname is unset!') unless @cfname
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Truncate_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           IRE = 1
           UE = 2
 
-          ::Thrift::Struct.field_accessor self, :ire, :ue
           FIELDS = {
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException},
             UE => {:type => ::Thrift::Types::STRUCT, :name => 'ue', :class => CassandraThrift::UnavailableException}
@@ -1415,10 +1414,11 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_schema_versions_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
 
           FIELDS = {
 
@@ -1429,14 +1429,14 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_schema_versions_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
 
-          ::Thrift::Struct.field_accessor self, :success, :ire
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::MAP, :name => 'success', :key => {:type => ::Thrift::Types::STRING}, :value => {:type => ::Thrift::Types::LIST, :element => {:type => ::Thrift::Types::STRING}}},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException}
@@ -1447,10 +1447,11 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_keyspaces_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
 
           FIELDS = {
 
@@ -1461,14 +1462,14 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_keyspaces_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
 
-          ::Thrift::Struct.field_accessor self, :success, :ire
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::LIST, :name => 'success', :element => {:type => ::Thrift::Types::STRUCT, :class => CassandraThrift::KsDef}},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException}
@@ -1479,10 +1480,11 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_cluster_name_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
 
           FIELDS = {
 
@@ -1493,13 +1495,13 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_cluster_name_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
 
-          ::Thrift::Struct.field_accessor self, :success
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::STRING, :name => 'success'}
           }
@@ -1509,10 +1511,11 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_version_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
 
           FIELDS = {
 
@@ -1523,13 +1526,13 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_version_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
 
-          ::Thrift::Struct.field_accessor self, :success
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::STRING, :name => 'success'}
           }
@@ -1539,13 +1542,13 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_ring_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           KEYSPACE = 1
 
-          ::Thrift::Struct.field_accessor self, :keyspace
           FIELDS = {
             KEYSPACE => {:type => ::Thrift::Types::STRING, :name => 'keyspace'}
           }
@@ -1556,14 +1559,14 @@ require 'cassandra_types'
             raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field keyspace is unset!') unless @keyspace
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_ring_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
 
-          ::Thrift::Struct.field_accessor self, :success, :ire
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::LIST, :name => 'success', :element => {:type => ::Thrift::Types::STRUCT, :class => CassandraThrift::TokenRange}},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException}
@@ -1574,10 +1577,11 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_partitioner_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
 
           FIELDS = {
 
@@ -1588,13 +1592,13 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_partitioner_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
 
-          ::Thrift::Struct.field_accessor self, :success
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::STRING, :name => 'success'}
           }
@@ -1604,10 +1608,11 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_snitch_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
 
           FIELDS = {
 
@@ -1618,13 +1623,13 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_snitch_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
 
-          ::Thrift::Struct.field_accessor self, :success
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::STRING, :name => 'success'}
           }
@@ -1634,13 +1639,13 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_keyspace_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           KEYSPACE = 1
 
-          ::Thrift::Struct.field_accessor self, :keyspace
           FIELDS = {
             KEYSPACE => {:type => ::Thrift::Types::STRING, :name => 'keyspace'}
           }
@@ -1651,15 +1656,15 @@ require 'cassandra_types'
             raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field keyspace is unset!') unless @keyspace
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_keyspace_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           NFE = 1
           IRE = 2
 
-          ::Thrift::Struct.field_accessor self, :success, :nfe, :ire
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::STRUCT, :name => 'success', :class => CassandraThrift::KsDef},
             NFE => {:type => ::Thrift::Types::STRUCT, :name => 'nfe', :class => CassandraThrift::NotFoundException},
@@ -1671,16 +1676,16 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_splits_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           CFNAME = 1
           START_TOKEN = 2
           END_TOKEN = 3
           KEYS_PER_SPLIT = 4
 
-          ::Thrift::Struct.field_accessor self, :cfName, :start_token, :end_token, :keys_per_split
           FIELDS = {
             CFNAME => {:type => ::Thrift::Types::STRING, :name => 'cfName'},
             START_TOKEN => {:type => ::Thrift::Types::STRING, :name => 'start_token'},
@@ -1697,13 +1702,13 @@ require 'cassandra_types'
             raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field keys_per_split is unset!') unless @keys_per_split
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class Describe_splits_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
 
-          ::Thrift::Struct.field_accessor self, :success
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::LIST, :name => 'success', :element => {:type => ::Thrift::Types::STRING}}
           }
@@ -1713,13 +1718,13 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class System_add_column_family_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           CF_DEF = 1
 
-          ::Thrift::Struct.field_accessor self, :cf_def
           FIELDS = {
             CF_DEF => {:type => ::Thrift::Types::STRUCT, :name => 'cf_def', :class => CassandraThrift::CfDef}
           }
@@ -1730,14 +1735,14 @@ require 'cassandra_types'
             raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field cf_def is unset!') unless @cf_def
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class System_add_column_family_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
 
-          ::Thrift::Struct.field_accessor self, :success, :ire
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::STRING, :name => 'success'},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException}
@@ -1748,13 +1753,13 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class System_drop_column_family_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           COLUMN_FAMILY = 1
 
-          ::Thrift::Struct.field_accessor self, :column_family
           FIELDS = {
             COLUMN_FAMILY => {:type => ::Thrift::Types::STRING, :name => 'column_family'}
           }
@@ -1765,14 +1770,14 @@ require 'cassandra_types'
             raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field column_family is unset!') unless @column_family
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class System_drop_column_family_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
 
-          ::Thrift::Struct.field_accessor self, :success, :ire
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::STRING, :name => 'success'},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException}
@@ -1783,13 +1788,13 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class System_add_keyspace_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           KS_DEF = 1
 
-          ::Thrift::Struct.field_accessor self, :ks_def
           FIELDS = {
             KS_DEF => {:type => ::Thrift::Types::STRUCT, :name => 'ks_def', :class => CassandraThrift::KsDef}
           }
@@ -1800,14 +1805,14 @@ require 'cassandra_types'
             raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field ks_def is unset!') unless @ks_def
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class System_add_keyspace_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
 
-          ::Thrift::Struct.field_accessor self, :success, :ire
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::STRING, :name => 'success'},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException}
@@ -1818,13 +1823,13 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class System_drop_keyspace_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           KEYSPACE = 1
 
-          ::Thrift::Struct.field_accessor self, :keyspace
           FIELDS = {
             KEYSPACE => {:type => ::Thrift::Types::STRING, :name => 'keyspace'}
           }
@@ -1835,14 +1840,14 @@ require 'cassandra_types'
             raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field keyspace is unset!') unless @keyspace
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class System_drop_keyspace_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
 
-          ::Thrift::Struct.field_accessor self, :success, :ire
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::STRING, :name => 'success'},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException}
@@ -1853,13 +1858,13 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class System_update_keyspace_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           KS_DEF = 1
 
-          ::Thrift::Struct.field_accessor self, :ks_def
           FIELDS = {
             KS_DEF => {:type => ::Thrift::Types::STRUCT, :name => 'ks_def', :class => CassandraThrift::KsDef}
           }
@@ -1870,14 +1875,14 @@ require 'cassandra_types'
             raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field ks_def is unset!') unless @ks_def
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class System_update_keyspace_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
 
-          ::Thrift::Struct.field_accessor self, :success, :ire
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::STRING, :name => 'success'},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException}
@@ -1888,13 +1893,13 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class System_update_column_family_args
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           CF_DEF = 1
 
-          ::Thrift::Struct.field_accessor self, :cf_def
           FIELDS = {
             CF_DEF => {:type => ::Thrift::Types::STRUCT, :name => 'cf_def', :class => CassandraThrift::CfDef}
           }
@@ -1905,14 +1910,14 @@ require 'cassandra_types'
             raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field cf_def is unset!') unless @cf_def
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
         class System_update_column_family_result
-          include ::Thrift::Struct
+          include ::Thrift::Struct, ::Thrift::Struct_Union
           SUCCESS = 0
           IRE = 1
 
-          ::Thrift::Struct.field_accessor self, :success, :ire
           FIELDS = {
             SUCCESS => {:type => ::Thrift::Types::STRING, :name => 'success'},
             IRE => {:type => ::Thrift::Types::STRUCT, :name => 'ire', :class => CassandraThrift::InvalidRequestException}
@@ -1923,6 +1928,7 @@ require 'cassandra_types'
           def validate
           end
 
+          ::Thrift::Struct.generate_accessors self
         end
 
       end

--- a/vendor/0.7/gen-rb/cassandra_constants.rb
+++ b/vendor/0.7/gen-rb/cassandra_constants.rb
@@ -7,6 +7,6 @@
 require 'cassandra_types'
 
   module CassandraThrift
-    VERSION = %q"17.1.0"
+    VERSION = %q"19.4.0"
 
 end

--- a/vendor/0.7/gen-rb/cassandra_types.rb
+++ b/vendor/0.7/gen-rb/cassandra_types.rb
@@ -7,15 +7,14 @@
 
 module CassandraThrift
     module ConsistencyLevel
-      ZERO = 0
       ONE = 1
       QUORUM = 2
-      DCQUORUM = 3
-      DCQUORUMSYNC = 4
+      LOCAL_QUORUM = 3
+      EACH_QUORUM = 4
       ALL = 5
       ANY = 6
-      VALUE_MAP = {0 => "ZERO", 1 => "ONE", 2 => "QUORUM", 3 => "DCQUORUM", 4 => "DCQUORUMSYNC", 5 => "ALL", 6 => "ANY"}
-      VALID_VALUES = Set.new([ZERO, ONE, QUORUM, DCQUORUM, DCQUORUMSYNC, ALL, ANY]).freeze
+      VALUE_MAP = {1 => "ONE", 2 => "QUORUM", 3 => "LOCAL_QUORUM", 4 => "EACH_QUORUM", 5 => "ALL", 6 => "ANY"}
+      VALID_VALUES = Set.new([ONE, QUORUM, LOCAL_QUORUM, EACH_QUORUM, ALL, ANY]).freeze
     end
 
     module IndexOperator
@@ -599,7 +598,6 @@ module CassandraThrift
       SUBCOMPARATOR_TYPE = 6
       COMMENT = 8
       ROW_CACHE_SIZE = 9
-      PRELOAD_ROW_CACHE = 10
       KEY_CACHE_SIZE = 11
       READ_REPAIR_CHANCE = 12
       COLUMN_METADATA = 13
@@ -608,8 +606,13 @@ module CassandraThrift
       ID = 16
       MIN_COMPACTION_THRESHOLD = 17
       MAX_COMPACTION_THRESHOLD = 18
+      ROW_CACHE_SAVE_PERIOD_IN_SECONDS = 19
+      KEY_CACHE_SAVE_PERIOD_IN_SECONDS = 20
+      MEMTABLE_FLUSH_AFTER_MINS = 21
+      MEMTABLE_THROUGHPUT_IN_MB = 22
+      MEMTABLE_OPERATIONS_IN_MILLIONS = 23
 
-      ::Thrift::Struct.field_accessor self, :keyspace, :name, :column_type, :comparator_type, :subcomparator_type, :comment, :row_cache_size, :preload_row_cache, :key_cache_size, :read_repair_chance, :column_metadata, :gc_grace_seconds, :default_validation_class, :id, :min_compaction_threshold, :max_compaction_threshold
+      ::Thrift::Struct.field_accessor self, :keyspace, :name, :column_type, :comparator_type, :subcomparator_type, :comment, :row_cache_size, :key_cache_size, :read_repair_chance, :column_metadata, :gc_grace_seconds, :default_validation_class, :id, :min_compaction_threshold, :max_compaction_threshold, :row_cache_save_period_in_seconds, :key_cache_save_period_in_seconds, :memtable_flush_after_mins, :memtable_throughput_in_mb, :memtable_operations_in_millions
       FIELDS = {
         KEYSPACE => {:type => ::Thrift::Types::STRING, :name => 'keyspace'},
         NAME => {:type => ::Thrift::Types::STRING, :name => 'name'},
@@ -618,7 +621,6 @@ module CassandraThrift
         SUBCOMPARATOR_TYPE => {:type => ::Thrift::Types::STRING, :name => 'subcomparator_type', :optional => true},
         COMMENT => {:type => ::Thrift::Types::STRING, :name => 'comment', :optional => true},
         ROW_CACHE_SIZE => {:type => ::Thrift::Types::DOUBLE, :name => 'row_cache_size', :default => 0, :optional => true},
-        PRELOAD_ROW_CACHE => {:type => ::Thrift::Types::BOOL, :name => 'preload_row_cache', :default => false, :optional => true},
         KEY_CACHE_SIZE => {:type => ::Thrift::Types::DOUBLE, :name => 'key_cache_size', :default => 200000, :optional => true},
         READ_REPAIR_CHANCE => {:type => ::Thrift::Types::DOUBLE, :name => 'read_repair_chance', :default => 1, :optional => true},
         COLUMN_METADATA => {:type => ::Thrift::Types::LIST, :name => 'column_metadata', :element => {:type => ::Thrift::Types::STRUCT, :class => CassandraThrift::ColumnDef}, :optional => true},
@@ -626,7 +628,12 @@ module CassandraThrift
         DEFAULT_VALIDATION_CLASS => {:type => ::Thrift::Types::STRING, :name => 'default_validation_class', :optional => true},
         ID => {:type => ::Thrift::Types::I32, :name => 'id', :optional => true},
         MIN_COMPACTION_THRESHOLD => {:type => ::Thrift::Types::I32, :name => 'min_compaction_threshold', :optional => true},
-        MAX_COMPACTION_THRESHOLD => {:type => ::Thrift::Types::I32, :name => 'max_compaction_threshold', :optional => true}
+        MAX_COMPACTION_THRESHOLD => {:type => ::Thrift::Types::I32, :name => 'max_compaction_threshold', :optional => true},
+        ROW_CACHE_SAVE_PERIOD_IN_SECONDS => {:type => ::Thrift::Types::I32, :name => 'row_cache_save_period_in_seconds', :optional => true},
+        KEY_CACHE_SAVE_PERIOD_IN_SECONDS => {:type => ::Thrift::Types::I32, :name => 'key_cache_save_period_in_seconds', :optional => true},
+        MEMTABLE_FLUSH_AFTER_MINS => {:type => ::Thrift::Types::I32, :name => 'memtable_flush_after_mins', :optional => true},
+        MEMTABLE_THROUGHPUT_IN_MB => {:type => ::Thrift::Types::I32, :name => 'memtable_throughput_in_mb', :optional => true},
+        MEMTABLE_OPERATIONS_IN_MILLIONS => {:type => ::Thrift::Types::DOUBLE, :name => 'memtable_operations_in_millions', :optional => true}
       }
 
       def struct_fields; FIELDS; end

--- a/vendor/0.7/gen-rb/cassandra_types.rb
+++ b/vendor/0.7/gen-rb/cassandra_types.rb
@@ -39,16 +39,15 @@ module CassandraThrift
     # @param timestamp. The timestamp is used for conflict detection/resolution when two columns with same name need to be compared.
     # @param ttl. An optional, positive delay (in seconds) after which the column will be automatically deleted.
     class Column
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       NAME = 1
       VALUE = 2
       TIMESTAMP = 3
       TTL = 4
 
-      ::Thrift::Struct.field_accessor self, :name, :value, :timestamp, :ttl
       FIELDS = {
-        NAME => {:type => ::Thrift::Types::STRING, :name => 'name'},
-        VALUE => {:type => ::Thrift::Types::STRING, :name => 'value'},
+        NAME => {:type => ::Thrift::Types::STRING, :name => 'name', :binary => true},
+        VALUE => {:type => ::Thrift::Types::STRING, :name => 'value', :binary => true},
         TIMESTAMP => {:type => ::Thrift::Types::I64, :name => 'timestamp'},
         TTL => {:type => ::Thrift::Types::I32, :name => 'ttl', :optional => true}
       }
@@ -61,6 +60,7 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field timestamp is unset!') unless @timestamp
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # A named list of columns.
@@ -68,13 +68,12 @@ module CassandraThrift
     # @param columns. A collection of standard Columns.  The columns within a super column are defined in an adhoc manner.
     #                 Columns within a super column do not have to have matching structures (similarly named child columns).
     class SuperColumn
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       NAME = 1
       COLUMNS = 2
 
-      ::Thrift::Struct.field_accessor self, :name, :columns
       FIELDS = {
-        NAME => {:type => ::Thrift::Types::STRING, :name => 'name'},
+        NAME => {:type => ::Thrift::Types::STRING, :name => 'name', :binary => true},
         COLUMNS => {:type => ::Thrift::Types::LIST, :name => 'columns', :element => {:type => ::Thrift::Types::STRUCT, :class => CassandraThrift::Column}}
       }
 
@@ -85,6 +84,7 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field columns is unset!') unless @columns
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # Methods for fetching rows/records from Cassandra will return either a single instance of ColumnOrSuperColumn or a list
@@ -96,11 +96,10 @@ module CassandraThrift
     # @param column. The Column returned by get() or get_slice().
     # @param super_column. The SuperColumn returned by get() or get_slice().
     class ColumnOrSuperColumn
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       COLUMN = 1
       SUPER_COLUMN = 2
 
-      ::Thrift::Struct.field_accessor self, :column, :super_column
       FIELDS = {
         COLUMN => {:type => ::Thrift::Types::STRUCT, :name => 'column', :class => CassandraThrift::Column, :optional => true},
         SUPER_COLUMN => {:type => ::Thrift::Types::STRUCT, :name => 'super_column', :class => CassandraThrift::SuperColumn, :optional => true}
@@ -111,11 +110,12 @@ module CassandraThrift
       def validate
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # A specific column was requested that does not exist.
     class NotFoundException < ::Thrift::Exception
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
 
       FIELDS = {
 
@@ -126,12 +126,13 @@ module CassandraThrift
       def validate
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # Invalid request could mean keyspace or column family does not exist, required parameters are missing, or a parameter is malformed.
     # why contains an associated error message.
     class InvalidRequestException < ::Thrift::Exception
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       def initialize(message=nil)
         super()
         self.why = message
@@ -141,7 +142,6 @@ module CassandraThrift
 
       WHY = 1
 
-      ::Thrift::Struct.field_accessor self, :why
       FIELDS = {
         WHY => {:type => ::Thrift::Types::STRING, :name => 'why'}
       }
@@ -152,11 +152,12 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field why is unset!') unless @why
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # Not all the replicas required could be created and/or read.
     class UnavailableException < ::Thrift::Exception
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
 
       FIELDS = {
 
@@ -167,11 +168,12 @@ module CassandraThrift
       def validate
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # RPC timeout was exceeded.  either a node failed mid-operation, or load was too high, or the requested op was too large.
     class TimedOutException < ::Thrift::Exception
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
 
       FIELDS = {
 
@@ -182,11 +184,12 @@ module CassandraThrift
       def validate
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # invalid authentication request (invalid keyspace, user does not exist, or credentials invalid)
     class AuthenticationException < ::Thrift::Exception
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       def initialize(message=nil)
         super()
         self.why = message
@@ -196,7 +199,6 @@ module CassandraThrift
 
       WHY = 1
 
-      ::Thrift::Struct.field_accessor self, :why
       FIELDS = {
         WHY => {:type => ::Thrift::Types::STRING, :name => 'why'}
       }
@@ -207,11 +209,12 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field why is unset!') unless @why
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # invalid authorization request (user does not have access to keyspace)
     class AuthorizationException < ::Thrift::Exception
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       def initialize(message=nil)
         super()
         self.why = message
@@ -221,7 +224,6 @@ module CassandraThrift
 
       WHY = 1
 
-      ::Thrift::Struct.field_accessor self, :why
       FIELDS = {
         WHY => {:type => ::Thrift::Types::STRING, :name => 'why'}
       }
@@ -232,6 +234,7 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field why is unset!') unless @why
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # ColumnParent is used when selecting groups of columns from the same ColumnFamily. In directory structure terms, imagine
@@ -239,14 +242,13 @@ module CassandraThrift
     # 
     # See also <a href="cassandra.html#Struct_ColumnPath">ColumnPath</a>
     class ColumnParent
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       COLUMN_FAMILY = 3
       SUPER_COLUMN = 4
 
-      ::Thrift::Struct.field_accessor self, :column_family, :super_column
       FIELDS = {
         COLUMN_FAMILY => {:type => ::Thrift::Types::STRING, :name => 'column_family'},
-        SUPER_COLUMN => {:type => ::Thrift::Types::STRING, :name => 'super_column', :optional => true}
+        SUPER_COLUMN => {:type => ::Thrift::Types::STRING, :name => 'super_column', :binary => true, :optional => true}
       }
 
       def struct_fields; FIELDS; end
@@ -255,6 +257,7 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field column_family is unset!') unless @column_family
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # The ColumnPath is the path to a single column in Cassandra. It might make sense to think of ColumnPath and
@@ -266,16 +269,15 @@ module CassandraThrift
     # @param super_column. The super column name.
     # @param column. The column name.
     class ColumnPath
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       COLUMN_FAMILY = 3
       SUPER_COLUMN = 4
       COLUMN = 5
 
-      ::Thrift::Struct.field_accessor self, :column_family, :super_column, :column
       FIELDS = {
         COLUMN_FAMILY => {:type => ::Thrift::Types::STRING, :name => 'column_family'},
-        SUPER_COLUMN => {:type => ::Thrift::Types::STRING, :name => 'super_column', :optional => true},
-        COLUMN => {:type => ::Thrift::Types::STRING, :name => 'column', :optional => true}
+        SUPER_COLUMN => {:type => ::Thrift::Types::STRING, :name => 'super_column', :binary => true, :optional => true},
+        COLUMN => {:type => ::Thrift::Types::STRING, :name => 'column', :binary => true, :optional => true}
       }
 
       def struct_fields; FIELDS; end
@@ -284,6 +286,7 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field column_family is unset!') unless @column_family
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # A slice range is a structure that stores basic range, ordering and limit information for a query that will return
@@ -301,16 +304,15 @@ module CassandraThrift
     #               be better served by iterating through slices by passing the last value of one call in as the 'start'
     #               of the next instead of increasing 'count' arbitrarily large.
     class SliceRange
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       START = 1
       FINISH = 2
       REVERSED = 3
       COUNT = 4
 
-      ::Thrift::Struct.field_accessor self, :start, :finish, :reversed, :count
       FIELDS = {
-        START => {:type => ::Thrift::Types::STRING, :name => 'start'},
-        FINISH => {:type => ::Thrift::Types::STRING, :name => 'finish'},
+        START => {:type => ::Thrift::Types::STRING, :name => 'start', :binary => true},
+        FINISH => {:type => ::Thrift::Types::STRING, :name => 'finish', :binary => true},
         REVERSED => {:type => ::Thrift::Types::BOOL, :name => 'reversed', :default => false},
         COUNT => {:type => ::Thrift::Types::I32, :name => 'count', :default => 100}
       }
@@ -324,6 +326,7 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field count is unset!') unless @count
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # A SlicePredicate is similar to a mathematic predicate (see http://en.wikipedia.org/wiki/Predicate_(mathematical_logic)),
@@ -337,13 +340,12 @@ module CassandraThrift
     #                     and 'Jim' you can pass those column names as a list to fetch all three at once.
     # @param slice_range. A SliceRange describing how to range, order, and/or limit the slice.
     class SlicePredicate
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       COLUMN_NAMES = 1
       SLICE_RANGE = 2
 
-      ::Thrift::Struct.field_accessor self, :column_names, :slice_range
       FIELDS = {
-        COLUMN_NAMES => {:type => ::Thrift::Types::LIST, :name => 'column_names', :element => {:type => ::Thrift::Types::STRING}, :optional => true},
+        COLUMN_NAMES => {:type => ::Thrift::Types::LIST, :name => 'column_names', :element => {:type => ::Thrift::Types::STRING, :binary => true}, :optional => true},
         SLICE_RANGE => {:type => ::Thrift::Types::STRUCT, :name => 'slice_range', :class => CassandraThrift::SliceRange, :optional => true}
       }
 
@@ -352,19 +354,19 @@ module CassandraThrift
       def validate
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     class IndexExpression
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       COLUMN_NAME = 1
       OP = 2
       VALUE = 3
 
-      ::Thrift::Struct.field_accessor self, :column_name, :op, :value
       FIELDS = {
-        COLUMN_NAME => {:type => ::Thrift::Types::STRING, :name => 'column_name'},
+        COLUMN_NAME => {:type => ::Thrift::Types::STRING, :name => 'column_name', :binary => true},
         OP => {:type => ::Thrift::Types::I32, :name => 'op', :enum_class => CassandraThrift::IndexOperator},
-        VALUE => {:type => ::Thrift::Types::STRING, :name => 'value'}
+        VALUE => {:type => ::Thrift::Types::STRING, :name => 'value', :binary => true}
       }
 
       def struct_fields; FIELDS; end
@@ -378,18 +380,18 @@ module CassandraThrift
         end
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     class IndexClause
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       EXPRESSIONS = 1
       START_KEY = 2
       COUNT = 3
 
-      ::Thrift::Struct.field_accessor self, :expressions, :start_key, :count
       FIELDS = {
         EXPRESSIONS => {:type => ::Thrift::Types::LIST, :name => 'expressions', :element => {:type => ::Thrift::Types::STRUCT, :class => CassandraThrift::IndexExpression}},
-        START_KEY => {:type => ::Thrift::Types::STRING, :name => 'start_key'},
+        START_KEY => {:type => ::Thrift::Types::STRING, :name => 'start_key', :binary => true},
         COUNT => {:type => ::Thrift::Types::I32, :name => 'count', :default => 100}
       }
 
@@ -401,6 +403,7 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field count is unset!') unless @count
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # The semantics of start keys and tokens are slightly different.
@@ -410,17 +413,16 @@ module CassandraThrift
     # one-element range, but a range from tokenY to tokenY is the
     # full ring.
     class KeyRange
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       START_KEY = 1
       END_KEY = 2
       START_TOKEN = 3
       END_TOKEN = 4
       COUNT = 5
 
-      ::Thrift::Struct.field_accessor self, :start_key, :end_key, :start_token, :end_token, :count
       FIELDS = {
-        START_KEY => {:type => ::Thrift::Types::STRING, :name => 'start_key', :optional => true},
-        END_KEY => {:type => ::Thrift::Types::STRING, :name => 'end_key', :optional => true},
+        START_KEY => {:type => ::Thrift::Types::STRING, :name => 'start_key', :binary => true, :optional => true},
+        END_KEY => {:type => ::Thrift::Types::STRING, :name => 'end_key', :binary => true, :optional => true},
         START_TOKEN => {:type => ::Thrift::Types::STRING, :name => 'start_token', :optional => true},
         END_TOKEN => {:type => ::Thrift::Types::STRING, :name => 'end_token', :optional => true},
         COUNT => {:type => ::Thrift::Types::I32, :name => 'count', :default => 100}
@@ -432,6 +434,7 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field count is unset!') unless @count
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # A KeySlice is key followed by the data it maps to. A collection of KeySlice is returned by the get_range_slice operation.
@@ -440,13 +443,12 @@ module CassandraThrift
     # @param columns. List of data represented by the key. Typically, the list is pared down to only the columns specified by
     #                 a SlicePredicate.
     class KeySlice
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       KEY = 1
       COLUMNS = 2
 
-      ::Thrift::Struct.field_accessor self, :key, :columns
       FIELDS = {
-        KEY => {:type => ::Thrift::Types::STRING, :name => 'key'},
+        KEY => {:type => ::Thrift::Types::STRING, :name => 'key', :binary => true},
         COLUMNS => {:type => ::Thrift::Types::LIST, :name => 'columns', :element => {:type => ::Thrift::Types::STRUCT, :class => CassandraThrift::ColumnOrSuperColumn}}
       }
 
@@ -457,16 +459,16 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field columns is unset!') unless @columns
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     class KeyCount
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       KEY = 1
       COUNT = 2
 
-      ::Thrift::Struct.field_accessor self, :key, :count
       FIELDS = {
-        KEY => {:type => ::Thrift::Types::STRING, :name => 'key'},
+        KEY => {:type => ::Thrift::Types::STRING, :name => 'key', :binary => true},
         COUNT => {:type => ::Thrift::Types::I32, :name => 'count'}
       }
 
@@ -477,18 +479,18 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field count is unset!') unless @count
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     class Deletion
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       TIMESTAMP = 1
       SUPER_COLUMN = 2
       PREDICATE = 3
 
-      ::Thrift::Struct.field_accessor self, :timestamp, :super_column, :predicate
       FIELDS = {
         TIMESTAMP => {:type => ::Thrift::Types::I64, :name => 'timestamp'},
-        SUPER_COLUMN => {:type => ::Thrift::Types::STRING, :name => 'super_column', :optional => true},
+        SUPER_COLUMN => {:type => ::Thrift::Types::STRING, :name => 'super_column', :binary => true, :optional => true},
         PREDICATE => {:type => ::Thrift::Types::STRUCT, :name => 'predicate', :class => CassandraThrift::SlicePredicate, :optional => true}
       }
 
@@ -498,17 +500,17 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field timestamp is unset!') unless @timestamp
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # A Mutation is either an insert, represented by filling column_or_supercolumn, or a deletion, represented by filling the deletion attribute.
     # @param column_or_supercolumn. An insert to a column or supercolumn
     # @param deletion. A deletion of a column or supercolumn
     class Mutation
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       COLUMN_OR_SUPERCOLUMN = 1
       DELETION = 2
 
-      ::Thrift::Struct.field_accessor self, :column_or_supercolumn, :deletion
       FIELDS = {
         COLUMN_OR_SUPERCOLUMN => {:type => ::Thrift::Types::STRUCT, :name => 'column_or_supercolumn', :class => CassandraThrift::ColumnOrSuperColumn, :optional => true},
         DELETION => {:type => ::Thrift::Types::STRUCT, :name => 'deletion', :class => CassandraThrift::Deletion, :optional => true}
@@ -519,15 +521,15 @@ module CassandraThrift
       def validate
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     class TokenRange
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       START_TOKEN = 1
       END_TOKEN = 2
       ENDPOINTS = 3
 
-      ::Thrift::Struct.field_accessor self, :start_token, :end_token, :endpoints
       FIELDS = {
         START_TOKEN => {:type => ::Thrift::Types::STRING, :name => 'start_token'},
         END_TOKEN => {:type => ::Thrift::Types::STRING, :name => 'end_token'},
@@ -542,14 +544,14 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field endpoints is unset!') unless @endpoints
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     # Authentication requests can contain any data, dependent on the IAuthenticator used
     class AuthenticationRequest
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       CREDENTIALS = 1
 
-      ::Thrift::Struct.field_accessor self, :credentials
       FIELDS = {
         CREDENTIALS => {:type => ::Thrift::Types::MAP, :name => 'credentials', :key => {:type => ::Thrift::Types::STRING}, :value => {:type => ::Thrift::Types::STRING}}
       }
@@ -560,18 +562,18 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field credentials is unset!') unless @credentials
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     class ColumnDef
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       NAME = 1
       VALIDATION_CLASS = 2
       INDEX_TYPE = 3
       INDEX_NAME = 4
 
-      ::Thrift::Struct.field_accessor self, :name, :validation_class, :index_type, :index_name
       FIELDS = {
-        NAME => {:type => ::Thrift::Types::STRING, :name => 'name'},
+        NAME => {:type => ::Thrift::Types::STRING, :name => 'name', :binary => true},
         VALIDATION_CLASS => {:type => ::Thrift::Types::STRING, :name => 'validation_class'},
         INDEX_TYPE => {:type => ::Thrift::Types::I32, :name => 'index_type', :optional => true, :enum_class => CassandraThrift::IndexType},
         INDEX_NAME => {:type => ::Thrift::Types::STRING, :name => 'index_name', :optional => true}
@@ -587,10 +589,11 @@ module CassandraThrift
         end
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     class CfDef
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       KEYSPACE = 1
       NAME = 2
       COLUMN_TYPE = 3
@@ -612,7 +615,6 @@ module CassandraThrift
       MEMTABLE_THROUGHPUT_IN_MB = 22
       MEMTABLE_OPERATIONS_IN_MILLIONS = 23
 
-      ::Thrift::Struct.field_accessor self, :keyspace, :name, :column_type, :comparator_type, :subcomparator_type, :comment, :row_cache_size, :key_cache_size, :read_repair_chance, :column_metadata, :gc_grace_seconds, :default_validation_class, :id, :min_compaction_threshold, :max_compaction_threshold, :row_cache_save_period_in_seconds, :key_cache_save_period_in_seconds, :memtable_flush_after_mins, :memtable_throughput_in_mb, :memtable_operations_in_millions
       FIELDS = {
         KEYSPACE => {:type => ::Thrift::Types::STRING, :name => 'keyspace'},
         NAME => {:type => ::Thrift::Types::STRING, :name => 'name'},
@@ -643,17 +645,17 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field name is unset!') unless @name
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
     class KsDef
-      include ::Thrift::Struct
+      include ::Thrift::Struct, ::Thrift::Struct_Union
       NAME = 1
       STRATEGY_CLASS = 2
       STRATEGY_OPTIONS = 3
       REPLICATION_FACTOR = 4
       CF_DEFS = 5
 
-      ::Thrift::Struct.field_accessor self, :name, :strategy_class, :strategy_options, :replication_factor, :cf_defs
       FIELDS = {
         NAME => {:type => ::Thrift::Types::STRING, :name => 'name'},
         STRATEGY_CLASS => {:type => ::Thrift::Types::STRING, :name => 'strategy_class'},
@@ -671,6 +673,7 @@ module CassandraThrift
         raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field cf_defs is unset!') unless @cf_defs
       end
 
+      ::Thrift::Struct.generate_accessors self
     end
 
   end


### PR DESCRIPTION
2 commits here, the earlier one regens the thrift interface for cassandra 0.7rc1 using older thrift, and updates ruby code to remove functions removed from cassandra api

The second regens using thrift 0.5.0, and forces a gem dependency on it in lib/cassandra.rb.  Note that you should update the version for thrift_client once its next version # is set (hopefully including my 0.5.0 dependency)
