### PR TITLE
Cassandra::Mock#get does not match range query behavior for standard CFs

### DIFF
--- a/lib/cassandra/mock.rb
+++ b/lib/cassandra/mock.rb
@@ -89,6 +89,18 @@ class Cassandra
       if column
         row[column]
       else
+        # TODO: extract this to apply_range
+        if options[:start] || options[:finish]
+          start  = to_compare_with_type(options[:start],  column_family)
+          finish = to_compare_with_type(options[:finish], column_family)
+          ret = OrderedHash.new
+          row.keys.each do |key|
+            if (start.nil? || key >= start) && (finish.nil? || key <= finish)
+              ret[key] = row[key]
+            end
+          end
+          row = ret
+        end
         apply_count(row, options[:count], options[:reversed])
       end
     end

--- a/lib/cassandra/mock.rb
+++ b/lib/cassandra/mock.rb
@@ -89,18 +89,7 @@ class Cassandra
       if column
         row[column]
       else
-        # TODO: extract this to apply_range
-        if options[:start] || options[:finish]
-          start  = to_compare_with_type(options[:start],  column_family)
-          finish = to_compare_with_type(options[:finish], column_family)
-          ret = OrderedHash.new
-          row.keys.each do |key|
-            if (start.nil? || key >= start) && (finish.nil? || key <= finish)
-              ret[key] = row[key]
-            end
-          end
-          row = ret
-        end
+        row = apply_range(row, column_family, options[:start], options[:finish])
         apply_count(row, options[:count], options[:reversed])
       end
     end
@@ -119,17 +108,7 @@ class Cassandra
           row = cf(column_family)[key] && cf(column_family)[key][column] ?
             cf(column_family)[key][column] :
             OrderedHash.new
-          if options[:start] || options[:finish]
-            start  = to_compare_with_type(options[:start],  column_family, false)
-            finish = to_compare_with_type(options[:finish], column_family, false)
-            ret = OrderedHash.new
-            row.keys.each do |key|
-              if (start.nil? || key >= start) && (finish.nil? || key <= finish)
-                ret[key] = row[key]
-              end
-            end
-            row = ret
-          end
+          row = apply_range(row, column_family, options[:start], options[:finish], false)
           apply_count(row, options[:count], options[:reversed])
         end
       elsif cf(column_family)[key]
@@ -330,5 +309,18 @@ class Cassandra
         row
       end
     end
+
+    def apply_range(row, column_family, strt, fin, standard=true)
+      start  = to_compare_with_type(strt, column_family, standard)
+      finish = to_compare_with_type(fin,  column_family, standard)
+      ret = OrderedHash.new
+      row.keys.each do |key|
+        if (start.nil? || key >= start) && (finish.nil? || key <= finish)
+          ret[key] = row[key]
+        end
+      end
+      ret
+    end
+
   end
 end

--- a/test/cassandra_test.rb
+++ b/test/cassandra_test.rb
@@ -102,6 +102,18 @@ class CassandraTest < Test::Unit::TestCase
     assert !@twitter.exists?(:Statuses, 'bogus', 'body')
   end
 
+  def test_get_value_with_range
+    10.times do |i|
+      @twitter.insert(:Statuses, key, {"body-#{i}" => 'v'})
+    end
+
+    assert_equal 5, @twitter.get(:Statuses, key, :count => 5).length
+    assert_equal 5, @twitter.get(:Statuses, key, :start => "body-5").length
+    assert_equal 5, @twitter.get(:Statuses, key, :finish => "body-4").length
+    assert_equal 5, @twitter.get(:Statuses, key, :start => "body-1", :count => 5).length
+    assert_equal 5, @twitter.get(:Statuses, key, :start => "body-0", :finish => "body-4", :count => 7).length
+  end
+
   def test_exists_with_only_key
     @twitter.insert(:Statuses, key, {'body' => 'v'})
     assert @twitter.exists?(:Statuses, key)


### PR DESCRIPTION
It seems like `Cassandra::Mock#get` doesn't implement the `:start` and `:finish` options when reading from standard CFs. Supercolumn CFs seem to work, so I extracted that behavior and added it to the codepath for standard CFs. 

The new behavior seems consistent with how Cassandra (0.6) works.
