### PR TITLE
Only require json when using 0.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v0.9.dev Support for secondary indexing. (jhermes)
+v0.9.1 Support for secondary indexing. (jhermes)
 Fix bug in mock where we didn't support range queries. (therealadam)
 Support deletes in batch mutations. [blanquer]
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v0.9.dev Support for secondary indexing. (jhermes)
 Fix bug in mock where we didn't support range queries. (therealadam)
+Support deletes in batch mutations. [blanquer]
 
 v0.9.0 cassandra 0.7 compat
 

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ end
 
 CASSANDRA_HOME = ENV['CASSANDRA_HOME'] || "#{ENV['HOME']}/cassandra"
 DOWNLOAD_DIR = "/tmp"
-DIST_URL = "http://www.takeyellow.com/apachemirror//cassandra/0.6.8/apache-cassandra-0.6.8-bin.tar.gz"
+DIST_URL = "http://www.fightrice.com/mirrors/apache/cassandra/0.6.12/apache-cassandra-0.6.12-bin.tar.gz"
 DIST_FILE = DIST_URL.split('/').last
 
 directory CASSANDRA_HOME

--- a/lib/cassandra.rb
+++ b/lib/cassandra.rb
@@ -6,14 +6,14 @@ require 'thrift_client'
 gem 'simple_uuid' , '~> 0.1.0'
 require 'simple_uuid'
 
-require 'json' unless defined?(JSON)
-
 here = File.expand_path(File.dirname(__FILE__))
 
 class Cassandra ; end
 unless Cassandra.respond_to?(:VERSION)
   require "#{here}/cassandra/0.6"
 end
+
+require 'json' unless defined?(JSON) || Cassandra.VERSION != "0.6"
 
 $LOAD_PATH << "#{here}/../vendor/#{Cassandra.VERSION}/gen-rb"
 require "#{here}/../vendor/#{Cassandra.VERSION}/gen-rb/cassandra"

--- a/lib/cassandra/cassandra.rb
+++ b/lib/cassandra/cassandra.rb
@@ -226,8 +226,8 @@ class Cassandra
     end
   end
 
-  # Return a list of keys in the column_family you request. Requires the
-  # table to be partitioned with OrderPreservingHash. Supports the
+  # Return a list of keys in the column_family you request. Only works well if
+  # the table is partitioned with OrderPreservingPartitioner. Supports the
   # <tt>:count</tt>, <tt>:start</tt>, <tt>:finish</tt>, and <tt>:consistency</tt>
   # options.
   def get_range(column_family, options = {})


### PR DESCRIPTION
Looks like the json gem is not require when using 0.6. 
