### PR TITLE
OrderHash bug fix

### DIFF
--- a/lib/cassandra/ordered_hash.rb
+++ b/lib/cassandra/ordered_hash.rb
@@ -156,13 +156,13 @@ class Cassandra
       super
     end
 
-    def delete_if
-      @timestamps.delete_if
+    def delete_if(&block)
+      @timestamps.delete_if(&block)
       super
     end
 
-    def reject!
-      @timestamps.reject!
+    def reject!(&block)
+      @timestamps.reject!(&block)
       super
     end
 

--- a/lib/cassandra/ordered_hash.rb
+++ b/lib/cassandra/ordered_hash.rb
@@ -189,12 +189,5 @@ class Cassandra
     def inspect
       "#<OrderedHash #{super}\n#{@timestamps.inspect}>"
     end
-
-  private
-
-    def sync_keys!
-      @timestamps.delete_if {|k,v| !has_key?(k)}
-      super
-    end
   end
 end

--- a/test/ordered_hash_test.rb
+++ b/test/ordered_hash_test.rb
@@ -321,6 +321,7 @@ class OrderedHashTest < Test::Unit::TestCase
     @ordered_hash.reject! { |k, _| k == 'pink' }
     assert_equal copy, @ordered_hash
     assert !@ordered_hash.keys.include?('pink')
+    assert !@ordered_hash.timestamps.keys.include?('pink')
   end
 
   def test_reject


### PR DESCRIPTION
Note that in addition to making things work, the &block fix is necessary for ordered_hash_test.rb to pass and for the code to run on ruby 1.8.6.
