### PR TITLE
Support for real batch mutations

### DIFF
--- a/lib/cassandra/0.7/columns.rb
+++ b/lib/cassandra/0.7/columns.rb
@@ -55,5 +55,31 @@ class Cassandra
         )
       )
     end
+
+    # General info about a deletion object within a mutation
+    # timestamp - required. If this is the only param, it will cause deletion of the whole key at that TS
+    # supercolumn - opt. If passed, the deletes will only occur within that supercolumn (only subcolumns 
+    #               will be deleted). Otherwise the normal columns will be deleted.
+    # predicate - opt. Defines how to match the columns to delete. if supercolumn passed, the slice will 
+    #               be scoped to subcolumns of that supercolumn.
+    
+    # Deletes a single column from the containing key/CF (and possibly supercolumn), at a given timestamp. 
+    # Although mutations (as opposed to 'remove' calls) support deleting slices and lists of columns in one shot, this is not implemented here.
+    # The main reason being that the batch function takes removes, but removes don't have that capability...so we'd need to change the remove
+    # methods to use delete mutation calls...although that might have performance implications. We'll leave that refactoring for later.
+    def _delete_mutation(cf, column, subcolumn, timestamp, options={})
+      
+      deletion_hash = {:timestamp => timestamp}
+      if is_super(cf)
+         deletion_hash[:super_column] = column if column
+         deletion_hash[:predicate] = CassandraThrift::SlicePredicate.new(:column_names => [subcolumn]) if subcolumn
+     else
+         deletion_hash[:predicate] = CassandraThrift::SlicePredicate.new(:column_names => [column]) if column
+      end
+      CassandraThrift::Mutation.new(
+        :deletion => CassandraThrift::Deletion.new(deletion_hash)
+        )      
+    end
+   
   end
 end

--- a/lib/cassandra/mock.rb
+++ b/lib/cassandra/mock.rb
@@ -133,7 +133,7 @@ class Cassandra
     def remove(column_family, key, *columns_and_options)
       column_family, column, sub_column, options = extract_and_validate_params_for_real(column_family, key, columns_and_options, WRITE_DEFAULTS)
       if @batch
-        @batch << [:remove, column_family, key, column]
+        @batch << [:remove, column_family, key, column, sub_column]
       else
         if column
           if sub_column


### PR DESCRIPTION
Added support for batch mutations (including batch deletes). Support for slice-ranges/multicolumn deletion mutations not implemented (since the batch mutation can mix removes and mutation-deletes but removes only support single column deletes)...so some more serious refactoring would need to be done to do that well. Enhanced mutation tests. Fixed a bug in the mutate mock class (and covered that case in a test)
