### PR TITLE
Bug fix for some batch deletion cases

### DIFF
--- a/lib/cassandra/cassandra.rb
+++ b/lib/cassandra/cassandra.rb
@@ -146,7 +146,7 @@ class Cassandra
       mutation_map = 
         {
           key => {
-            column_family => [ _delete_mutation(column_family , is_super(column_family)? column : nil , sub_column , options[:timestamp]|| Time.stamp) ]
+            column_family => [ _delete_mutation(column_family , column , sub_column , options[:timestamp]|| Time.stamp) ]
           }
         }  
       @batch << [mutation_map, options[:consistency]]

--- a/lib/cassandra/helpers.rb
+++ b/lib/cassandra/helpers.rb
@@ -17,6 +17,7 @@ class Cassandra
 
       # Ranges
       column, sub_column = args[0], args[1]
+      raise ArgumentError, "Invalid arguments: subcolumns specified for a non-supercolumn family" if sub_column && !is_super(column_family)      
       klass, sub_klass = column_name_class(column_family), sub_column_name_class(column_family)
       range_class = column ? sub_klass : klass
 

--- a/lib/cassandra/mock.rb
+++ b/lib/cassandra/mock.rb
@@ -16,6 +16,7 @@ class Cassandra
     include ::Cassandra::Columns
 
     def initialize(keyspace, storage_xml)
+      @is_super = {}
       @keyspace = keyspace
       @column_name_class = {}
       @sub_column_name_class = {}


### PR DESCRIPTION
Fix batch mutation bug. Added more test coverage and throw an exception when trying to access subcolumns for a non-super CF.
