### PR TITLE
Updated Test Suite and Added 0.8 Compatability

### DIFF
--- a/conf/0.6/schema.json
+++ b/conf/0.6/schema.json
@@ -1,0 +1,48 @@
+{"Twitter":{
+    "Users":{
+      "CompareWith":"org.apache.cassandra.db.marshal.UTF8Type",
+      "Type":"Standard"},
+    "UserAudits":{
+      "CompareWith":"org.apache.cassandra.db.marshal.UTF8Type",
+      "Type":"Standard"},
+    "UserRelationships":{ 
+      "CompareSubcolumnsWith":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "CompareWith":"org.apache.cassandra.db.marshal.UTF8Type",
+      "Type":"Super"},
+    "Usernames":{
+      "CompareWith":"org.apache.cassandra.db.marshal.UTF8Type",
+      "Type":"Standard"},
+    "Statuses":{
+      "CompareWith":"org.apache.cassandra.db.marshal.UTF8Type",
+      "Type":"Standard"},
+    "StatusAudits":{
+      "CompareWith":"org.apache.cassandra.db.marshal.UTF8Type",
+      "Type":"Standard"},
+    "StatusRelationships":{
+      "CompareSubcolumnsWith":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "CompareWith":"org.apache.cassandra.db.marshal.UTF8Type",
+      "Type":"Super"},
+    "Index":{
+      "CompareWith":"org.apache.cassandra.db.marshal.UTF8Type",
+      "Type":"Super"},
+    "TimelinishThings":{
+      "CompareWith":"org.apache.cassandra.db.marshal.BytesType",
+      "Type":"Standard"}
+  },
+"Multiblog":{
+    "Blogs":{
+      "CompareWith":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "Type":"Standard"},
+    "Comments":{
+      "CompareWith":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "Type":"Standard"}
+  },
+"MultiblogLong":{
+    "Blogs":{
+      "CompareWith":"org.apache.cassandra.db.marshal.LongType",
+      "Type":"Standard"},
+    "Comments":{
+      "CompareWith":"org.apache.cassandra.db.marshal.LongType",
+      "Type":"Standard"}
+  }
+}

--- a/conf/0.7/cassandra.in.sh
+++ b/conf/0.7/cassandra.in.sh
@@ -38,3 +38,9 @@ CLASSPATH=$CASSANDRA_CONF:$cassandra_bin
 for jar in $CASSANDRA_HOME/lib/*.jar; do
   CLASSPATH=$CLASSPATH:$jar
 done
+
+# Arguments to pass to the JVM
+JVM_OPTS=" \
+        -ea \
+        -Xms128M \
+        -Xmx1G"

--- a/conf/0.7/schema.json
+++ b/conf/0.7/schema.json
@@ -1,48 +1,48 @@
 {"Twitter":{
     "Users":{
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Standard"},
     "UserAudits":{
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Standard"},
     "UserRelationships":{ 
-      "subcomparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "subcomparator_type":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Super"},
     "Usernames":{
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Standard"},
     "Statuses":{
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Standard"},
     "StatusAudits":{
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Standard"},
     "StatusRelationships":{
-      "subcomparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "subcomparator_type":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Super"},
     "Index":{
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Super"},
     "TimelinishThings":{
-      "comparator":"org.apache.cassandra.db.marshal.BytesType",
+      "comparator_type":"org.apache.cassandra.db.marshal.BytesType",
       "column_type":"Standard"}
   },
 "Multiblog":{
     "Blogs":{
-      "comparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "comparator_type":"org.apache.cassandra.db.marshal.TimeUUIDType",
       "column_type":"Standard"},
     "Comments":{
-      "comparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "comparator_type":"org.apache.cassandra.db.marshal.TimeUUIDType",
       "column_type":"Standard"}
   },
 "MultiblogLong":{
     "Blogs":{
-      "comparator":"org.apache.cassandra.db.marshal.LongType",
+      "comparator_type":"org.apache.cassandra.db.marshal.LongType",
       "column_type":"Standard"},
     "Comments":{
-      "comparator":"org.apache.cassandra.db.marshal.LongType",
+      "comparator_type":"org.apache.cassandra.db.marshal.LongType",
       "column_type":"Standard"}
   }
 }

--- a/conf/0.7/schema.json
+++ b/conf/0.7/schema.json
@@ -1,0 +1,48 @@
+{"Twitter":{
+    "Users":{
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Standard"},
+    "UserAudits":{
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Standard"},
+    "UserRelationships":{ 
+      "subcomparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Super"},
+    "Usernames":{
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Standard"},
+    "Statuses":{
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Standard"},
+    "StatusAudits":{
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Standard"},
+    "StatusRelationships":{
+      "subcomparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Super"},
+    "Index":{
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Super"},
+    "TimelinishThings":{
+      "comparator":"org.apache.cassandra.db.marshal.BytesType",
+      "column_type":"Standard"}
+  },
+"Multiblog":{
+    "Blogs":{
+      "comparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "column_type":"Standard"},
+    "Comments":{
+      "comparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "column_type":"Standard"}
+  },
+"MultiblogLong":{
+    "Blogs":{
+      "comparator":"org.apache.cassandra.db.marshal.LongType",
+      "column_type":"Standard"},
+    "Comments":{
+      "comparator":"org.apache.cassandra.db.marshal.LongType",
+      "column_type":"Standard"}
+  }
+}

--- a/conf/0.8/schema.json
+++ b/conf/0.8/schema.json
@@ -1,48 +1,48 @@
 {"Twitter":{
     "Users":{
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Standard"},
     "UserAudits":{
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Standard"},
     "UserRelationships":{ 
-      "subcomparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "subcomparator_type":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Super"},
     "Usernames":{
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Standard"},
     "Statuses":{
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Standard"},
     "StatusAudits":{
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Standard"},
     "StatusRelationships":{
-      "subcomparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "subcomparator_type":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Super"},
     "Index":{
-      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "comparator_type":"org.apache.cassandra.db.marshal.UTF8Type",
       "column_type":"Super"},
     "TimelinishThings":{
-      "comparator":"org.apache.cassandra.db.marshal.BytesType",
+      "comparator_type":"org.apache.cassandra.db.marshal.BytesType",
       "column_type":"Standard"}
   },
 "Multiblog":{
     "Blogs":{
-      "comparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "comparator_type":"org.apache.cassandra.db.marshal.TimeUUIDType",
       "column_type":"Standard"},
     "Comments":{
-      "comparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "comparator_type":"org.apache.cassandra.db.marshal.TimeUUIDType",
       "column_type":"Standard"}
   },
 "MultiblogLong":{
     "Blogs":{
-      "comparator":"org.apache.cassandra.db.marshal.LongType",
+      "comparator_type":"org.apache.cassandra.db.marshal.LongType",
       "column_type":"Standard"},
     "Comments":{
-      "comparator":"org.apache.cassandra.db.marshal.LongType",
+      "comparator_type":"org.apache.cassandra.db.marshal.LongType",
       "column_type":"Standard"}
   }
 }

--- a/conf/0.8/schema.json
+++ b/conf/0.8/schema.json
@@ -1,0 +1,48 @@
+{"Twitter":{
+    "Users":{
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Standard"},
+    "UserAudits":{
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Standard"},
+    "UserRelationships":{ 
+      "subcomparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Super"},
+    "Usernames":{
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Standard"},
+    "Statuses":{
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Standard"},
+    "StatusAudits":{
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Standard"},
+    "StatusRelationships":{
+      "subcomparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Super"},
+    "Index":{
+      "comparator":"org.apache.cassandra.db.marshal.UTF8Type",
+      "column_type":"Super"},
+    "TimelinishThings":{
+      "comparator":"org.apache.cassandra.db.marshal.BytesType",
+      "column_type":"Standard"}
+  },
+"Multiblog":{
+    "Blogs":{
+      "comparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "column_type":"Standard"},
+    "Comments":{
+      "comparator":"org.apache.cassandra.db.marshal.TimeUUIDType",
+      "column_type":"Standard"}
+  },
+"MultiblogLong":{
+    "Blogs":{
+      "comparator":"org.apache.cassandra.db.marshal.LongType",
+      "column_type":"Standard"},
+    "Comments":{
+      "comparator":"org.apache.cassandra.db.marshal.LongType",
+      "column_type":"Standard"}
+  }
+}

--- a/lib/cassandra/0.6/cassandra.rb
+++ b/lib/cassandra/0.6/cassandra.rb
@@ -14,6 +14,7 @@ class Cassandra
       remove(column_family, key, options)
     end
   end
+  alias truncate! clear_column_family!
 
   # Remove all rows in the keyspace. Supports options <tt>:consistency</tt> and
   # <tt>:timestamp</tt>.

--- a/lib/cassandra/0.6/protocol.rb
+++ b/lib/cassandra/0.6/protocol.rb
@@ -47,14 +47,11 @@ class Cassandra
       # Single values; count and range parameters have no effect
       if is_super(column_family) and sub_column
         column_path = CassandraThrift::ColumnPath.new(:column_family => column_family, :super_column => column, :column => sub_column)
-        column_hash = multi_column_to_hash!(client.multiget(@keyspace, keys, column_path, consistency))
-
-        keys.inject({}){|hash, key| hash[key] = column_hash[key][column]; hash}
+        multi_column_to_hash!(client.multiget(@keyspace, keys, column_path, consistency))
       elsif !is_super(column_family) and column
         column_path = CassandraThrift::ColumnPath.new(:column_family => column_family, :column => column)
-        column_hash = multi_column_to_hash!(client.multiget(@keyspace, keys, column_path, consistency))
+        multi_column_to_hash!(client.multiget(@keyspace, keys, column_path, consistency))
 
-        keys.inject({}){|hash, key| hash[key] = column_hash[key][column]; hash}
       # Slices
       else
         predicate = CassandraThrift::SlicePredicate.new(:slice_range => 

--- a/lib/cassandra/0.6/protocol.rb
+++ b/lib/cassandra/0.6/protocol.rb
@@ -47,11 +47,14 @@ class Cassandra
       # Single values; count and range parameters have no effect
       if is_super(column_family) and sub_column
         column_path = CassandraThrift::ColumnPath.new(:column_family => column_family, :super_column => column, :column => sub_column)
-        multi_column_to_hash!(client.multiget(@keyspace, keys, column_path, consistency))
+        column_hash = multi_column_to_hash!(client.multiget(@keyspace, keys, column_path, consistency))
+
+        keys.inject({}){|hash, key| hash[key] = column_hash[key][column]; hash}
       elsif !is_super(column_family) and column
         column_path = CassandraThrift::ColumnPath.new(:column_family => column_family, :column => column)
-        multi_column_to_hash!(client.multiget(@keyspace, keys, column_path, consistency))
+        column_hash = multi_column_to_hash!(client.multiget(@keyspace, keys, column_path, consistency))
 
+        keys.inject({}){|hash, key| hash[key] = column_hash[key][column]; hash}
       # Slices
       else
         predicate = CassandraThrift::SlicePredicate.new(:slice_range => 

--- a/lib/cassandra/0.7/cassandra.rb
+++ b/lib/cassandra/0.7/cassandra.rb
@@ -57,11 +57,9 @@ class Cassandra
 
   # Remove all rows in the column family you request.
   def truncate!(column_family)
-    #each_key(column_family) do |key|
-    #  remove(column_family, key, options)
-    #end
-    client.truncate(column_family)
+    client.truncate(column_family.to_s)
   end
+  alias clear_column_family! truncate!
 
   # Remove all rows in the keyspace.
   def clear_keyspace!

--- a/lib/cassandra/0.7/cassandra.rb
+++ b/lib/cassandra/0.7/cassandra.rb
@@ -233,8 +233,10 @@ class Cassandra
   def get_indexed_slices(column_family, idx_clause, *columns_and_options)
     column_family, columns, _, options =
       extract_and_validate_params(column_family, [], columns_and_options, READ_DEFAULTS)
-    _get_indexed_slices(column_family, idx_clause, columns, options[:count], options[:start],
+    key_slices = _get_indexed_slices(column_family, idx_clause, columns, options[:count], options[:start],
       options[:finish], options[:reversed], options[:consistency])
+
+    key_slices.inject({}){|h, key_slice| h[key_slice.key] = key_slice.columns; h}
   end
 
   protected

--- a/lib/cassandra/0.7/protocol.rb
+++ b/lib/cassandra/0.7/protocol.rb
@@ -46,7 +46,7 @@ class Cassandra
     def _multiget(column_family, keys, column, sub_column, count, start, finish, reversed, consistency)
       # Single values; count and range parameters have no effect
       if is_super(column_family) and sub_column
-        predicate = CassandraThrift::SlicePredicate.new(:column_names => [column])
+        predicate = CassandraThrift::SlicePredicate.new(:column_names => [sub_column])
         column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family, :super_column => column)
         multi_sub_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
 

--- a/lib/cassandra/0.7/protocol.rb
+++ b/lib/cassandra/0.7/protocol.rb
@@ -15,6 +15,11 @@ class Cassandra
     def _count_columns(column_family, key, super_column, consistency)
       client.get_count(key,
         CassandraThrift::ColumnParent.new(:column_family => column_family, :super_column => super_column),
+        CassandraThrift::SlicePredicate.new(:slice_range =>
+                                            CassandraThrift::SliceRange.new(
+                                              :start => '',
+                                              :finish => ''
+                                            )),
         consistency
       )
     end

--- a/lib/cassandra/0.7/protocol.rb
+++ b/lib/cassandra/0.7/protocol.rb
@@ -48,12 +48,16 @@ class Cassandra
       if is_super(column_family) and sub_column
         predicate = CassandraThrift::SlicePredicate.new(:column_names => [sub_column])
         column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family, :super_column => column)
-        multi_sub_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
+        column_hash = multi_sub_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
+
+        keys.inject({}){|hash, key| hash[key] = column_hash[key][column]; hash}
 
       elsif !is_super(column_family) and column
         predicate = CassandraThrift::SlicePredicate.new(:column_names => [column])
         column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family)
-        multi_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
+        column_hash  = multi_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
+
+        keys.inject({}){|hash, key| hash[key] = column_hash[key][column]; hash}
 
       # Slices
       else

--- a/lib/cassandra/0.7/protocol.rb
+++ b/lib/cassandra/0.7/protocol.rb
@@ -51,7 +51,7 @@ class Cassandra
     def _multiget(column_family, keys, column, sub_column, count, start, finish, reversed, consistency)
       # Single values; count and range parameters have no effect
       if is_super(column_family) and sub_column
-        predicate = CassandraThrift::SlicePredicate.new(:column_names => [sub_column])
+        predicate = CassandraThrift::SlicePredicate.new(:column_names => [column])
         column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family, :super_column => column)
         column_hash = multi_sub_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
 

--- a/lib/cassandra/0.7/protocol.rb
+++ b/lib/cassandra/0.7/protocol.rb
@@ -51,12 +51,12 @@ class Cassandra
     def _multiget(column_family, keys, column, sub_column, count, start, finish, reversed, consistency)
       # Single values; count and range parameters have no effect
       if is_super(column_family) and sub_column
-        predicate = CassandraThrift::SlicePredicate.new(:column_names => [column])
+        predicate = CassandraThrift::SlicePredicate.new(:column_names => [sub_column])
         column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family, :super_column => column)
         column_hash = multi_sub_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
 
-        keys.inject({}){|hash, key| hash[key] = column_hash[key][column]; hash}
-
+        klass = sub_column_name_class(column_family)
+        keys.inject({}){|hash, key| hash[key] = column_hash[key][klass.new(sub_column)]; hash}
       elsif !is_super(column_family) and column
         predicate = CassandraThrift::SlicePredicate.new(:column_names => [column])
         column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family)

--- a/lib/cassandra/0.8/cassandra.rb
+++ b/lib/cassandra/0.8/cassandra.rb
@@ -57,8 +57,9 @@ class Cassandra
 
   # Remove all rows in the column family you request.
   def truncate!(column_family)
-    client.truncate(column_family)
+    client.truncate(column_family.to_s)
   end
+  alias clear_column_family! truncate!
 
   # Remove all rows in the keyspace.
   def clear_keyspace!

--- a/lib/cassandra/0.8/cassandra.rb
+++ b/lib/cassandra/0.8/cassandra.rb
@@ -233,8 +233,10 @@ class Cassandra
   def get_indexed_slices(column_family, idx_clause, *columns_and_options)
     column_family, columns, _, options =
       extract_and_validate_params(column_family, [], columns_and_options, READ_DEFAULTS)
-    _get_indexed_slices(column_family, idx_clause, columns, options[:count], options[:start],
+    key_slices = _get_indexed_slices(column_family, idx_clause, columns, options[:count], options[:start],
       options[:finish], options[:reversed], options[:consistency])
+
+    key_slices.inject({}){|h, key_slice| h[key_slice.key] = key_slice.columns; h}
   end
 
   protected

--- a/lib/cassandra/0.8/protocol.rb
+++ b/lib/cassandra/0.8/protocol.rb
@@ -51,11 +51,12 @@ class Cassandra
     def _multiget(column_family, keys, column, sub_column, count, start, finish, reversed, consistency)
       # Single values; count and range parameters have no effect
       if is_super(column_family) and sub_column
-        predicate = CassandraThrift::SlicePredicate.new(:column_names => [column])
+        predicate = CassandraThrift::SlicePredicate.new(:column_names => [sub_column])
         column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family, :super_column => column)
         column_hash = multi_sub_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
 
-        keys.inject({}){|hash, key| hash[key] = column_hash[key][column]; hash}
+        klass = sub_column_name_class(column_family)
+        keys.inject({}){|hash, key| hash[key] = column_hash[key][klass.new(sub_column)]; hash}
       elsif !is_super(column_family) and column
         predicate = CassandraThrift::SlicePredicate.new(:column_names => [column])
         column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family)

--- a/lib/cassandra/0.8/protocol.rb
+++ b/lib/cassandra/0.8/protocol.rb
@@ -53,12 +53,15 @@ class Cassandra
       if is_super(column_family) and sub_column
         predicate = CassandraThrift::SlicePredicate.new(:column_names => [column])
         column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family, :super_column => column)
-        multi_sub_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
+        column_hash = multi_sub_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
 
+        keys.inject({}){|hash, key| hash[key] = column_hash[key][column]; hash}
       elsif !is_super(column_family) and column
         predicate = CassandraThrift::SlicePredicate.new(:column_names => [column])
         column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family)
-        multi_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
+        column_hash  = multi_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
+
+        keys.inject({}){|hash, key| hash[key] = column_hash[key][column]; hash}
 
       # Slices
       else

--- a/lib/cassandra/cassandra.rb
+++ b/lib/cassandra/cassandra.rb
@@ -146,7 +146,7 @@ class Cassandra
       mutation_map = 
         {
           key => {
-            column_family => [ _delete_mutation(column_family , column , sub_column , options[:timestamp]|| Time.stamp) ]
+            column_family => [ _delete_mutation(column_family, column, sub_column, options[:timestamp]|| Time.stamp) ]
           }
         }
       @batch << [mutation_map, options[:consistency]]

--- a/lib/cassandra/cassandra.rb
+++ b/lib/cassandra/cassandra.rb
@@ -146,7 +146,7 @@ class Cassandra
       mutation_map = 
         {
           key => {
-            column_family => [ _delete_mutation(column_family , is_super(column_family)? column : nil , sub_column , options[:timestamp]|| Time.stamp) ]
+            column_family => [ _delete_mutation(column_family, column, sub_column, options[:timestamp]|| Time.stamp) ]
           }
         }  
       @batch << [mutation_map, options[:consistency]]

--- a/lib/cassandra/mock.rb
+++ b/lib/cassandra/mock.rb
@@ -205,6 +205,10 @@ class Cassandra
 
     private
 
+    def schema_for_keyspace(keyspace)
+      @schema
+    end
+
     def _get_range(column_family, start, finish, count)
       ret = OrderedHash.new
       start  = to_compare_with_type(start,  column_family)

--- a/lib/cassandra/mock.rb
+++ b/lib/cassandra/mock.rb
@@ -283,7 +283,11 @@ class Cassandra
     end
 
     def column_family_type(column_family)
-      schema[column_family.to_s]['Type']
+      column_family_property(column_family, 'Type')
+    end
+
+    def column_family_property(column_family, property)
+      schema[column_family.to_s][property]
     end
 
     def cf(column_family)

--- a/lib/cassandra/mock.rb
+++ b/lib/cassandra/mock.rb
@@ -102,7 +102,7 @@ class Cassandra
       if column
         if sub_column
           if row[column] &&
-            row[column][sub_column] &&
+            row[column][sub_column]
             row[column][sub_column]
           else
             nil

--- a/test/cassandra_mock_test.rb
+++ b/test/cassandra_mock_test.rb
@@ -1,19 +1,20 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper')
-require 'cassandra_test'
+require File.expand_path(File.dirname(__FILE__) + '/cassandra_test')
 require 'cassandra/mock'
+require 'json'
 
 class CassandraMockTest < CassandraTest
   include Cassandra::Constants
 
   def setup
-    storage_xml_path = File.expand_path(File.join(File.dirname(File.dirname(__FILE__)), 'conf', 'storage-conf.xml'))
-    @twitter = Cassandra::Mock.new('Twitter', storage_xml_path)
+    schema = JSON.parse(File.read(File.join(File.expand_path(File.dirname(__FILE__)), '..','conf', CASSANDRA_VERSION, 'schema.json')))
+    @twitter = Cassandra::Mock.new('Twitter', schema)
     @twitter.clear_keyspace!
 
-    @blogs = Cassandra::Mock.new('Multiblog', storage_xml_path)
+    @blogs = Cassandra::Mock.new('Multiblog', schema)
     @blogs.clear_keyspace!
 
-    @blogs_long = Cassandra::Mock.new('MultiblogLong', storage_xml_path)
+    @blogs_long = Cassandra::Mock.new('MultiblogLong', schema)
     @blogs_long.clear_keyspace!
 
     @uuids = (0..6).map {|i| SimpleUUID::UUID.new(Time.at(2**(24+i))) }

--- a/test/cassandra_mock_test.rb
+++ b/test/cassandra_mock_test.rb
@@ -7,14 +7,14 @@ class CassandraMockTest < CassandraTest
   include Cassandra::Constants
 
   def setup
-    schema = JSON.parse(File.read(File.join(File.expand_path(File.dirname(__FILE__)), '..','conf', CASSANDRA_VERSION, 'schema.json')))
-    @twitter = Cassandra::Mock.new('Twitter', schema)
+    @test_schema = JSON.parse(File.read(File.join(File.expand_path(File.dirname(__FILE__)), '..','conf', CASSANDRA_VERSION, 'schema.json')))
+    @twitter = Cassandra::Mock.new('Twitter', @test_schema)
     @twitter.clear_keyspace!
 
-    @blogs = Cassandra::Mock.new('Multiblog', schema)
+    @blogs = Cassandra::Mock.new('Multiblog', @test_schema)
     @blogs.clear_keyspace!
 
-    @blogs_long = Cassandra::Mock.new('MultiblogLong', schema)
+    @blogs_long = Cassandra::Mock.new('MultiblogLong', @test_schema)
     @blogs_long.clear_keyspace!
 
     @uuids = (0..6).map {|i| SimpleUUID::UUID.new(Time.at(2**(24+i))) }
@@ -28,28 +28,7 @@ class CassandraMockTest < CassandraTest
   end
   
   def test_schema_for_keyspace
-    data = {
-      "StatusRelationships"=>{
-          "CompareSubcolumnsWith"=>"org.apache.cassandra.db.marshal.TimeUUIDType", 
-          "CompareWith"=>"org.apache.cassandra.db.marshal.UTF8Type",
-          "Type"=>"Super"},
-      "StatusAudits"=>{
-        "CompareWith"=>"org.apache.cassandra.db.marshal.UTF8Type",
-        "Type"=>"Standard"}, 
-      "Statuses"=>{
-        "CompareWith"=>"org.apache.cassandra.db.marshal.UTF8Type",
-        "Type"=>"Standard"}, 
-      "UserRelationships"=>{
-        "CompareSubcolumnsWith"=>"org.apache.cassandra.db.marshal.TimeUUIDType", 
-        "CompareWith"=>"org.apache.cassandra.db.marshal.UTF8Type",
-        "Type"=>"Super"}, 
-      "UserAudits"=>{
-        "CompareWith"=>"org.apache.cassandra.db.marshal.UTF8Type", 
-        "Type"=>"Standard"},
-      "Users"=>{"CompareWith"=>"org.apache.cassandra.db.marshal.UTF8Type", "Type"=>"Standard"},
-      "TimelinishThings"=>
-        {"CompareWith"=>"org.apache.cassandra.db.marshal.BytesType", "Type"=>"Standard"}
-    }
+    data = @test_schema['Twitter']
     stuff = @twitter.send(:schema_for_keyspace, 'Twitter')
     data.keys.each do |k|
       assert_equal data[k], stuff[k], k

--- a/test/cassandra_test.rb
+++ b/test/cassandra_test.rb
@@ -468,7 +468,7 @@ class CassandraTest < Test::Unit::TestCase
     assert_equal({'user' => 'user'}, @twitter.get(:Users, k))
   end
 
-  if CASSANDRA_VERSION == '0.7'
+  if CASSANDRA_VERSION.to_f >= 0.7
     def test_creating_and_dropping_new_index
       @twitter.create_index('Twitter', 'Statuses', 'column_name', 'LongType')
       assert_nil @twitter.create_index('Twitter', 'Statuses', 'column_name', 'LongType')
@@ -492,7 +492,7 @@ class CassandraTest < Test::Unit::TestCase
 
       indexed_row = @twitter.get_indexed_slices(:Statuses, idx_clause)
       assert_equal(1,      indexed_row.length)
-      assert_equal('row2', indexed_row.first.key)
+      assert_equal('row2', indexed_row.keys.first)
     end
   end
 

--- a/test/cassandra_test.rb
+++ b/test/cassandra_test.rb
@@ -456,12 +456,14 @@ class CassandraTest < Test::Unit::TestCase
   end
 
   def test_batch_over_deletes
+    k = key
+
     @twitter.batch do
-      @twitter.insert(:Users, key, {'body' => 'body', 'user' => 'user'})
-      @twitter.remove(:Users, key, 'body')
+      @twitter.insert(:Users, k, {'body' => 'body', 'user' => 'user'})
+      @twitter.remove(:Users, k, 'body')
     end
 
-    assert_equal({'user' => 'user'}, @twitter.get(:Users, key))
+    assert_equal({'user' => 'user'}, @twitter.get(:Users, k))
   end
 
   if CASSANDRA_VERSION == '0.7'

--- a/test/cassandra_test.rb
+++ b/test/cassandra_test.rb
@@ -103,15 +103,17 @@ class CassandraTest < Test::Unit::TestCase
   end
 
   def test_get_value_with_range
+    k = key
+
     10.times do |i|
-      @twitter.insert(:Statuses, key, {"body-#{i}" => 'v'})
+      @twitter.insert(:Statuses, k, {"body-#{i}" => 'v'})
     end
 
-    assert_equal 5, @twitter.get(:Statuses, key, :count => 5).length
-    assert_equal 5, @twitter.get(:Statuses, key, :start => "body-5").length
-    assert_equal 5, @twitter.get(:Statuses, key, :finish => "body-4").length
-    assert_equal 5, @twitter.get(:Statuses, key, :start => "body-1", :count => 5).length
-    assert_equal 5, @twitter.get(:Statuses, key, :start => "body-0", :finish => "body-4", :count => 7).length
+    assert_equal 5, @twitter.get(:Statuses, k, :count => 5).length
+    assert_equal 5, @twitter.get(:Statuses, k, :start => "body-5").length
+    assert_equal 5, @twitter.get(:Statuses, k, :finish => "body-4").length
+    assert_equal 5, @twitter.get(:Statuses, k, :start => "body-1", :count => 5).length
+    assert_equal 5, @twitter.get(:Statuses, k, :start => "body-0", :finish => "body-4", :count => 7).length
   end
 
   def test_exists_with_only_key

--- a/test/eventmachine_test.rb
+++ b/test/eventmachine_test.rb
@@ -1,42 +1,42 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 
-if RUBY_VERSION < '1.9'
+if RUBY_VERSION < '1.9' || CASSANDRA_VERSION == '0.6'
   puts "Skipping EventMachine test"
 else
 
-require 'thrift_client/event_machine'
+  require 'thrift_client/event_machine'
 
-class EventmachineTest < Test::Unit::TestCase
-  
-  def test_twitter
-    @twitter = Cassandra.new('Twitter', "127.0.0.1:9160", :retries => 2, :exception_classes => [], :transport => Thrift::EventMachineTransport, :transport_wrapper => nil)
-    @twitter.clear_keyspace!
-  end
+  class EventmachineTest < Test::Unit::TestCase
 
-  private
-  
-  def em_test(name)
-    EM.run do
-      Fiber.new do
-        begin
-          send("raw_#{name}".to_sym)
-        ensure
-          EM.stop
-        end
-      end.resume
+    def test_twitter
+      @twitter = Cassandra.new('Twitter', "127.0.0.1:9160", :retries => 2, :exception_classes => [], :transport => Thrift::EventMachineTransport, :transport_wrapper => nil)
+      @twitter.clear_keyspace!
     end
-  end
-  
-  def self.wrap_tests
-    self.public_instance_methods.select { |m| m =~ /^test_/ }.each do |meth|
-      alias_method :"raw_#{meth}", meth
-      define_method(meth) do
-        em_test(meth)
+
+    private
+
+    def em_test(name)
+      EM.run do
+        Fiber.new do
+          begin
+            send("raw_#{name}".to_sym)
+          ensure
+            EM.stop
+          end
+        end.resume
       end
     end
+
+    def self.wrap_tests
+      self.public_instance_methods.select { |m| m =~ /^test_/ }.each do |meth|
+        alias_method :"raw_#{meth}", meth
+        define_method(meth) do
+          em_test(meth)
+        end
+      end
+    end
+
+    wrap_tests
+
   end
-  
-  wrap_tests
-  
-end
 end


### PR DESCRIPTION
Please pull in the following new features and/or changes:
- Update Rakefile to install 0.6.13, 0.7.4, 0.8.0-beta1 to ~/cassandra/cassandra-VERSION
- Add data:load task to Rakefile for creating the schema required for the tests
- Default the Rakefile to use 0.8-beta1
- Setup test suite to work on 0.6.13, 0.7.4, and 0.8.0-beta1
- All tests pass for all supported (0.6.13, 0.7.4, 0.8.0-beta1) versions.
- Added Support for 0.8-beta1
- Changed get_index_slices to return a hash of rows
- Updated Cassandra::Mock to pass all tests for each Cassandra version
