### PR TITLE
Fix for string-based :start/:finish params to get_range()

### DIFF
--- a/lib/cassandra/cassandra.rb
+++ b/lib/cassandra/cassandra.rb
@@ -55,6 +55,8 @@ class Cassandra
     :count => 100,
     :start => nil,
     :finish => nil,
+    :start_key => nil,
+    :finish_key => nil,
     :reversed => false,
     :consistency => Consistency::ONE
   }.freeze
@@ -228,12 +230,12 @@ class Cassandra
 
   # Return a list of keys in the column_family you request. Only works well if
   # the table is partitioned with OrderPreservingPartitioner. Supports the
-  # <tt>:count</tt>, <tt>:start</tt>, <tt>:finish</tt>, and <tt>:consistency</tt>
-  # options.
+  # <tt>:count</tt>, <tt>:start_key</tt>, <tt>:finish_key</tt>, and
+  # <tt>:consistency</tt> options.
   def get_range(column_family, options = {})
     column_family, _, _, options = 
       extract_and_validate_params(column_family, "", [options], READ_DEFAULTS)
-    _get_range(column_family, options[:start].to_s, options[:finish].to_s, options[:count], options[:consistency])
+    _get_range(column_family, options[:start_key].to_s, options[:finish_key].to_s, options[:count], options[:consistency])
   end
 
   # Count all rows in the column_family you request. Requires the table


### PR DESCRIPTION
This commit fixes Issue 81.  Note that the `:start` parameter in the example code should be changed to `:start_key`, like so:

``` ruby
require 'cassandra/0.7'
conn = Cassandra.new(keyspace, '127.0.0.1:9160')
results  = conn.get_range(column_family, :count => 1)
results2 = conn.get_range(column_family, :count => 1,
                          :start_key => results.first.key)
```

The approach of this fix is kind of hacky and probably isn't ideal.  I suspect that adding two more keys to READ_DEFAULTS isn't desirable.  But I don't know how else to fix this.  Using `:start` and `:finish` can be ambiguous, since those parameters usually refer to column names, not keys.  (And, indeed, the problem is that the `extract_and_validate_params` method is treating them as column names.)
