### PR TITLE
#get returns nil

### DIFF
--- a/lib/cassandra/0.7/protocol.rb
+++ b/lib/cassandra/0.7/protocol.rb
@@ -53,16 +53,12 @@ class Cassandra
       if is_super(column_family) and sub_column
         predicate = CassandraThrift::SlicePredicate.new(:column_names => [sub_column])
         column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family, :super_column => column)
-        column_hash = multi_sub_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
+        multi_sub_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
 
-        klass = sub_column_name_class(column_family)
-        keys.inject({}){|hash, key| hash[key] = column_hash[key][klass.new(sub_column)]; hash}
       elsif !is_super(column_family) and column
         predicate = CassandraThrift::SlicePredicate.new(:column_names => [column])
         column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family)
-        column_hash  = multi_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
-
-        keys.inject({}){|hash, key| hash[key] = column_hash[key][column]; hash}
+        multi_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
 
       # Slices
       else

--- a/lib/cassandra/0.8/protocol.rb
+++ b/lib/cassandra/0.8/protocol.rb
@@ -53,16 +53,12 @@ class Cassandra
       if is_super(column_family) and sub_column
         predicate = CassandraThrift::SlicePredicate.new(:column_names => [sub_column])
         column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family, :super_column => column)
-        column_hash = multi_sub_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
+        multi_sub_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
 
-        klass = sub_column_name_class(column_family)
-        keys.inject({}){|hash, key| hash[key] = column_hash[key][klass.new(sub_column)]; hash}
       elsif !is_super(column_family) and column
         predicate = CassandraThrift::SlicePredicate.new(:column_names => [column])
         column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family)
-        column_hash  = multi_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
-
-        keys.inject({}){|hash, key| hash[key] = column_hash[key][column]; hash}
+        multi_columns_to_hash!(column_family, client.multiget_slice(keys, column_parent, predicate, consistency))
 
       # Slices
       else


### PR DESCRIPTION
At the head of the master branch, `Cassandra#get` doesn't return anything for me—even if I search for the same column I just inserted.  See the following code:

``` ruby
# Prefer the git repo version of the Cassandra library, not the gem version:
$:.unshift('/home/jeff/code/kyptin/cassandra/lib')
require 'cassandra/0.7'

# How to access Cassandra, and what to access.
@conn = Cassandra.new('testing', '127.0.0.1:9160')
@colfam = :SYN
@rowkey = 'a rowkey'
@colkey = 5302428712241737785

def get_column(msg)
  puts msg
  puts @conn.get(@colfam, @rowkey, @colkey).inspect
end

get_column("Before insert, got:")
@conn.insert(@colfam, @rowkey, { @colkey => "\x01" } )
get_column("\nAfter insert, got:")
@conn.remove(@colfam, @rowkey, @colkey)
get_column("\nAfter delete, got:")
```

This code breaks at commit 1c01e7c3858fbcb52291c07a2ab0913ca03e8b20: "Return single column value from _multiget when querying single value."  Just before that commit (at e271868fdf3fb3b3325f74dec90e16990a082026), the code above gives:

```
Before insert, got:
#<OrderedHash {}
{}>

After insert, got:
#<OrderedHash {<Cassandra::Long#13357100 time: 2011-01-09 01:57:39 UTC, usecs: 824643, jitter: 57, guid: 499602d2-0000-3039>=>"\x01"}
{<Cassandra::Long#13357100 time: 2011-01-09 01:57:39 UTC, usecs: 824643, jitter: 57, guid: 499602d2-0000-3039>=>1306257435339170}>

After delete, got:
#<OrderedHash {}
{}>
```

However, at commit 1c01e7, the code gives:

```
Before insert, got:
nil

After insert, got:
nil

After delete, got:
nil
```

My proposed change merely reverts commit 1c01e7c3858fbcb52291c07a2ab0913ca03e8b20.  Unfortunately, I don't know how to run the test suite, so I don't know what else my proposed change might break.
