### PR TITLE
Use post conn cb

### DIFF
--- a/lib/cassandra/cassandra.rb
+++ b/lib/cassandra/cassandra.rb
@@ -1007,7 +1007,6 @@ class Cassandra
   def client
     if @client.nil? || @client.current_server.nil?
       reconnect!
-      @client.set_keyspace(@keyspace)
     end
     @client
   end
@@ -1015,6 +1014,10 @@ class Cassandra
   def reconnect!
     @servers = all_nodes
     @client = new_client
+    @client.add_callback :post_connect do |cli|
+      # Set the active keyspace after connecting
+      cli.set_keyspace(@keyspace)
+    end
   end
 
   def all_nodes


### PR DESCRIPTION
Utilize the post connection callback support in thrift_client version 0.6.3 to reset the keyspace and optionally relogin.
