### PR TITLE
Found a bug with get_range call

### DIFF
--- a/lib/cassandra/cassandra.rb
+++ b/lib/cassandra/cassandra.rb
@@ -680,11 +680,11 @@ class Cassandra
   #   * :reversed     - If set to true the results will be returned in reverse order.
   #   * :consistency  - Uses the default read consistency if none specified.
   #
-  def get_range(column_family, options = {})
+  def get_range(column_family, options = {}, &blk)
     if block_given? || options[:key_count] || options[:batch_size]
-      get_range_batch(column_family, options)
+      get_range_batch(column_family, options, &blk)
     else
-      get_range_single(column_family, options)
+      get_range_single(column_family, options, &blk)
     end
   end
 

--- a/test/cassandra_test.rb
+++ b/test/cassandra_test.rb
@@ -259,6 +259,23 @@ class CassandraTest < Test::Unit::TestCase
     assert_equal(4, @twitter.get_range_keys(:Statuses, :key_count => 4).size)
   end
 
+  def test_get_range_block
+    k = key
+    5.times do |i|
+      @twitter.insert(:Statuses, k+i.to_s, {"body-#{i.to_s}" => 'v'})
+    end
+
+    values = (0..4).collect{|n| { :key => "test_get_range_block#{n}", :columns => { "body-#{n}" => "v" }} }.reverse
+
+    @twitter.get_range(:Statuses, :start_key => k.to_s, :key_count => 5) { |key,columns|
+       expected = values.pop
+       assert_equal expected[:key], key
+       assert_equal expected[:columns], columns
+    }
+    assert_equal [],values
+
+  end
+
   def test_each_key
     k = key
     keys_yielded = []


### PR DESCRIPTION
get_range's documentation promises to invoke a passed-in block for each row that's returned.  While both get_range_batch and get_range_single do this, get_range itself does not pass the block to its children.  I have amended this.
