### PR TITLE
Unable to pass finish_key to get_range_single

### DIFF
--- a/lib/cassandra/cassandra.rb
+++ b/lib/cassandra/cassandra.rb
@@ -700,7 +700,7 @@ class Cassandra
     column_family, _, _, options = 
       extract_and_validate_params(column_family, "", [options], 
                                   READ_DEFAULTS.merge(:start_key  => '',
-                                                      :end_key    => '',
+                                                      :finish_key => '',
                                                       :key_count  => 100,
                                                       :columns    => nil
                                                      )


### PR DESCRIPTION
I think there is a typo in get_range_single that replaces :finish_key with :end_key. This prevents passing :finish_key to get_range, because it ultimately gets passed to get_range_single.
