### PR TITLE
Added #keyspace and #add_column_family to Cassandra::Mock objects

### DIFF
--- a/lib/cassandra/cassandra.rb
+++ b/lib/cassandra/cassandra.rb
@@ -664,6 +664,9 @@ class Cassandra
   # deleted, but left in the system until the cluster has had resonable time to replicate the deletion.
   # This function attempts to suppress deleted rows (actually any row returned without
   # columns is suppressed).
+  # 
+  # Please note that when enabling the :reversed option, :start and :finish should be swapped (e.g.
+  # reversal happens before selecting the range).
   #
   # * column_family - The column_family that you are inserting into.
   # * key - The row key to insert.
@@ -702,7 +705,8 @@ class Cassandra
                                   READ_DEFAULTS.merge(:start_key  => '',
                                                       :finish_key => '',
                                                       :key_count  => 100,
-                                                      :columns    => nil
+                                                      :columns    => nil,
+                                                      :reversed   => false
                                                      )
                                  )
 
@@ -714,7 +718,8 @@ class Cassandra
                           options[:start].to_s,
                           options[:finish].to_s,
                           options[:count],
-                          options[:consistency] )
+                          options[:consistency],
+                          options[:reversed] )
 
     multi_key_slices_to_hash(column_family, results, return_empty_rows)
   end

--- a/lib/cassandra/mock.rb
+++ b/lib/cassandra/mock.rb
@@ -150,9 +150,9 @@ class Cassandra
       else
         if column
           if sub_column
-            cf(column_family)[key][column].delete(sub_column.to_s)
+            cf(column_family)[key][column].delete(sub_column.to_s) if cf(column_family)[key][column]
           else
-            cf(column_family)[key].delete(column.to_s)
+            cf(column_family)[key].delete(column.to_s)  if cf(column_family)[key]
           end
         else
           cf(column_family).delete(key)

--- a/lib/cassandra/mock.rb
+++ b/lib/cassandra/mock.rb
@@ -102,7 +102,7 @@ class Cassandra
         row[column]
       else
         row = apply_range(row, column_family, options[:start], options[:finish])
-        apply_count(row, options[:count], options[:reversed])
+        row = apply_count(row, options[:count], options[:reversed])
       end
     end
 
@@ -121,7 +121,7 @@ class Cassandra
         else
           row = row[column] || OrderedHash.new
           row = apply_range(row, column_family, options[:start], options[:finish], false)
-          apply_count(row, options[:count], options[:reversed])
+          row = apply_count(row, options[:count], options[:reversed])
         end
       else
         row
@@ -358,13 +358,12 @@ class Cassandra
           if columns
             #ret[key] = columns.inject(OrderedHash.new){|hash, column_name| hash[column_name] = cf(column_family)[key][column_name]; hash;}
             ret[key] = columns_to_hash(column_family, cf(column_family)[key].select{|k,v| columns.include?(k)})
-            ret[key] = ret[key].reverse if reversed
+            ret[key] = apply_count(ret[key], count, reversed)
             blk.call(key,ret[key]) unless blk.nil?
           else
             #ret[key] = apply_range(cf(column_family)[key], column_family, start, finish, !is_super(column_family))
-            row = columns_to_hash(column_family, cf(column_family)[key])
-            row = row.reverse if reversed
-            ret[key] = apply_range(row, column_family, start, finish)
+            ret[key] = apply_range(columns_to_hash(column_family, cf(column_family)[key]), column_family, start, finish)
+            ret[key] = apply_count(ret[key], count, reversed)
             blk.call(key,ret[key]) unless blk.nil?
           end
         end

--- a/lib/cassandra/mock.rb
+++ b/lib/cassandra/mock.rb
@@ -13,6 +13,8 @@ class Cassandra
     include ::Cassandra::Helpers
     include ::Cassandra::Columns
 
+    attr_reader :keyspace
+
     def initialize(keyspace, schema)
       @is_super = {}
       @keyspace = keyspace
@@ -330,6 +332,13 @@ class Cassandra
     def column_family_property(column_family, key)
       schema[column_family.to_s][key]
     end
+
+    def add_column_family(cf)
+      @schema[cf.name.to_s] ||= OrderedHash.new 
+      @schema[cf.name.to_s]["comparator_type"] = cf.comparator_type
+      @schema[cf.name.to_s]["column_type"] = cf.column_type || "Standard"
+    end
+
 
     private
 

--- a/lib/cassandra/ordered_hash.rb
+++ b/lib/cassandra/ordered_hash.rb
@@ -122,6 +122,10 @@ class Cassandra
         @keys = other.keys
         self
       end
+      
+      def reverse
+        OrderedHashInt[self.to_a.reverse]
+      end
 
     private
 

--- a/lib/cassandra/protocol.rb
+++ b/lib/cassandra/protocol.rb
@@ -85,7 +85,7 @@ class Cassandra
       end
     end
 
-    def _get_range(column_family, start_key, finish_key, key_count, columns, start, finish, count, consistency)
+    def _get_range(column_family, start_key, finish_key, key_count, columns, start, finish, count, consistency, reversed=false)
       column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family)
       predicate = if columns
                     CassandraThrift::SlicePredicate.new(:column_names => columns)
@@ -94,7 +94,8 @@ class Cassandra
                       CassandraThrift::SliceRange.new(
                         :start  => start, 
                         :finish => finish,
-                        :count  => count))
+                        :count  => count,
+                        :reversed => reversed))
                   end
       range = CassandraThrift::KeyRange.new(:start_key => start_key, :end_key => finish_key, :count => key_count)
       client.get_range_slices(column_parent, predicate, range, consistency)

--- a/test/cassandra_mock_test.rb
+++ b/test/cassandra_mock_test.rb
@@ -43,6 +43,19 @@ class CassandraMockTest < CassandraTest
     @twitter.insert(:Statuses, 'a', {:text => 'foo'})
     assert_equal ['a'], @twitter.get_range(:Statuses, :key_count => 1).keys
   end
+  
+  def test_get_range_reversed
+    data = 3.times.map { |i| ["body-#{i.to_s}", "v"] }
+    hash = Cassandra::OrderedHash[data]
+    reversed_hash = Cassandra::OrderedHash[data.reverse]
+    
+    @twitter.insert(:Statuses, "all-keys", hash)
+    
+    columns = @twitter.get_range(:Statuses, :reversed => true)["all-keys"]
+    columns.each do |column|
+      assert_equal reversed_hash.shift, column
+    end
+  end
 
   def test_inserting_array_for_indices
     @twitter.insert(:TimelinishThings, 'a', ['1','2'])

--- a/test/cassandra_mock_test.rb
+++ b/test/cassandra_mock_test.rb
@@ -56,6 +56,16 @@ class CassandraMockTest < CassandraTest
       assert_equal reversed_hash.shift, column
     end
   end
+  
+  def test_get_range_count
+    data = 3.times.map { |i| ["body-#{i.to_s}", "v"] }
+    hash = Cassandra::OrderedHash[data]
+    
+    @twitter.insert(:Statuses, "all-keys", hash)
+    
+    columns = @twitter.get_range(:Statuses, :count => 2)["all-keys"]
+    assert_equal 2, columns.count
+  end
 
   def test_inserting_array_for_indices
     @twitter.insert(:TimelinishThings, 'a', ['1','2'])

--- a/test/cassandra_test.rb
+++ b/test/cassandra_test.rb
@@ -275,6 +275,19 @@ class CassandraTest < Test::Unit::TestCase
     assert_equal [],values
 
   end
+  
+  def test_get_range_reversed
+    data = 3.times.map { |i| ["body-#{i.to_s}", "v"] }
+    hash = Cassandra::OrderedHash[data]
+    reversed_hash = Cassandra::OrderedHash[data.reverse]
+    
+    @twitter.insert(:Statuses, "all-keys", hash)
+    
+    columns = @twitter.get_range(:Statuses, :reversed => true)["all-keys"]
+    columns.each do |column|
+      assert_equal reversed_hash.shift, column
+    end
+  end
 
   def test_each_key
     k = key

--- a/test/ordered_hash_test.rb
+++ b/test/ordered_hash_test.rb
@@ -198,6 +198,11 @@ class OrderedHashTestInt < Test::Unit::TestCase
     assert_same original, @ordered_hash
     assert_equal @other_ordered_hash.keys, @ordered_hash.keys
   end
+  
+  def test_reverse
+    assert_equal @keys.reverse, @ordered_hash.reverse.keys
+    assert_equal @values.reverse, @ordered_hash.reverse.values
+  end
 end
 
 class OrderedHashTest < Test::Unit::TestCase


### PR DESCRIPTION
While trying to test an application that is using Cassandra we realized Cassandra::Mock wasn't covering for some of the methods in the Cassandra class.
