### PR TITLE
Support for :count option in mock object

### DIFF
--- a/lib/cassandra/mock.rb
+++ b/lib/cassandra/mock.rb
@@ -100,7 +100,7 @@ class Cassandra
         row[column]
       else
         row = apply_range(row, column_family, options[:start], options[:finish])
-        apply_count(row, options[:count], options[:reversed])
+        row = apply_count(row, options[:count], options[:reversed])
       end
     end
 
@@ -119,7 +119,7 @@ class Cassandra
         else
           row = row[column] || OrderedHash.new
           row = apply_range(row, column_family, options[:start], options[:finish], false)
-          apply_count(row, options[:count], options[:reversed])
+          row = apply_count(row, options[:count], options[:reversed])
         end
       else
         row
@@ -349,13 +349,12 @@ class Cassandra
           if columns
             #ret[key] = columns.inject(OrderedHash.new){|hash, column_name| hash[column_name] = cf(column_family)[key][column_name]; hash;}
             ret[key] = columns_to_hash(column_family, cf(column_family)[key].select{|k,v| columns.include?(k)})
-            ret[key] = ret[key].reverse if reversed
+            ret[key] = apply_count(ret[key], count, reversed)
             blk.call(key,ret[key]) unless blk.nil?
           else
             #ret[key] = apply_range(cf(column_family)[key], column_family, start, finish, !is_super(column_family))
-            row = columns_to_hash(column_family, cf(column_family)[key])
-            row = row.reverse if reversed
-            ret[key] = apply_range(row, column_family, start, finish)
+            ret[key] = apply_range(columns_to_hash(column_family, cf(column_family)[key]), column_family, start, finish)
+            ret[key] = apply_count(ret[key], count, reversed)
             blk.call(key,ret[key]) unless blk.nil?
           end
         end

--- a/test/cassandra_mock_test.rb
+++ b/test/cassandra_mock_test.rb
@@ -56,6 +56,16 @@ class CassandraMockTest < CassandraTest
       assert_equal reversed_hash.shift, column
     end
   end
+  
+  def test_get_range_count
+    data = 3.times.map { |i| ["body-#{i.to_s}", "v"] }
+    hash = Cassandra::OrderedHash[data]
+    
+    @twitter.insert(:Statuses, "all-keys", hash)
+    
+    columns = @twitter.get_range(:Statuses, :count => 2)["all-keys"]
+    assert_equal 2, columns.count
+  end
 
   def test_inserting_array_for_indices
     @twitter.insert(:TimelinishThings, 'a', ['1','2'])


### PR DESCRIPTION
Fix: the mock object was ignoring the :count parameter in _get_range() calls.
Now both :count and :reversed parameters in the mock are managed by the apply_count method().

This commit adds support for the :count parameter, which was ignored by the mock object.
It is also a slight improvement on my previous pull request, since it makes use of a method that was already in the mock (which I hadn't noticed before).
