### PR TITLE
Fixing mock get_range method

### DIFF
--- a/lib/cassandra/mock.rb
+++ b/lib/cassandra/mock.rb
@@ -398,6 +398,7 @@ class Cassandra
             blk.call(key,ret[key]) unless blk.nil?
           else
             #ret[key] = apply_range(cf(column_family)[key], column_family, start, finish, !is_super(column_family))
+            start, finish = finish, start if reversed
             ret[key] = apply_range(columns_to_hash(column_family, cf(column_family)[key]), column_family, start, finish)
             ret[key] = apply_count(ret[key], count, reversed)
             blk.call(key,ret[key]) unless blk.nil?

--- a/test/cassandra_mock_test.rb
+++ b/test/cassandra_mock_test.rb
@@ -57,6 +57,24 @@ class CassandraMockTest < CassandraTest
     end
   end
   
+  def test_get_range_reversed_slice
+    data = 4.times.map { |i| ["body-#{i.to_s}", "v"] }
+    hash = Cassandra::OrderedHash[data]
+    sliced_hash = Cassandra::OrderedHash[data.reverse[1..-1]]
+    
+    @twitter.insert(:Statuses, "all-keys", hash)
+    
+    columns = @twitter.get_range(
+      :Statuses,
+      :start => sliced_hash.keys.first,
+      :reversed => true
+    )["all-keys"]
+    
+    columns.each do |column|
+      assert_equal sliced_hash.shift, column
+    end
+  end
+  
   def test_get_range_count
     data = 3.times.map { |i| ["body-#{i.to_s}", "v"] }
     hash = Cassandra::OrderedHash[data]


### PR DESCRIPTION
Fix: Cassandra::Mock was not applying range correctly when the :reversed option was true and :finish was not specified.
