### PR TITLE
get_range_batch now correctly counts results for :key_count.

### DIFF
--- a/lib/cassandra/cassandra.rb
+++ b/lib/cassandra/cassandra.rb
@@ -741,19 +741,20 @@ class Cassandra
   # range of keys in the column_family you request.
   #
   # If a block is passed in we will yield the row key and columns for
-  # each record returned.
+  # each record returned and return a nil value instead of a Cassandra::OrderedHash.
   #
   # See Cassandra#get_range for more details.
   #
   def get_range_batch(column_family, options = {})
     batch_size    = options.delete(:batch_size) || 100
     count         = options.delete(:key_count)
-    result        = {}
+    result        = (!block_given? && {}) || nil
+    num_results    = 0
 
     options[:start_key] ||= ''
     last_key  = nil
 
-    while options[:start_key] != last_key && (count.nil? || count > result.length)
+    while options[:start_key] != last_key && (count.nil? || count > num_results)
       options[:start_key] = last_key
       res = get_range_single(column_family, options.merge!(:start_key => last_key,
                                                            :key_count => batch_size,
@@ -761,7 +762,7 @@ class Cassandra
                                                           ))
       res.each do |key, columns|
         next if options[:start_key] == key
-        next if result.length == count
+        next if num_results == count
 
         unless columns == {}
           if block_given?
@@ -769,12 +770,13 @@ class Cassandra
           else
             result[key] = columns
           end
+          num_results += 1
         end
         last_key = key
       end
     end
 
-    result if !block_given?
+    result
   end
 
   ##


### PR DESCRIPTION
I believe support for :key_count in get_range_batch broke with SHA: b0c4cb1a45feae3044b272120a1611d0f7d6e3d1 (#112).

```
shyamal@lambda:~/src/cassandra-ruby$ ruby ./test/cassandra_test.rb -n test_each
Loaded suite ./test/cassandra_test
Started
F
Finished in 2.336563 seconds.

  1) Failure:
test_each(CassandraTest) [./test/cassandra_test.rb:354]:
each limits to specified count.
<7> expected but was
<10>.

1 tests, 22 assertions, 1 failures, 0 errors
```

The fix for #112 does not record columns for each key to allow constant space operation in the presence of a block to yield to. In the process the count of result rows yielded is lost.

This patch explicitly counts returned results, and it explicitly uses a `nil` instead of a result hash for the constant space mode.

Apologies in advance if I am breaking some process by sending a pull request: I'm new to this code (and to github) and was unsure if I should open an issue or just send a pull request.
