### PR TITLE
Resolve an issue with CASSANDRA_HOME.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,8 +53,6 @@ def setup_environment
     env << "CASSANDRA_CONF=#{File.expand_path(Dir.pwd)}/conf/#{CASSANDRA_VERSION}"
   else
     env << "CASSANDRA_INCLUDE=#{ENV['CASSANDRA_INCLUDE']} "
-    env << "CASSANDRA_HOME=#{ENV['CASSANDRA_HOME']} "
-    env << "CASSANDRA_CONF=#{ENV['CASSANDRA_CONF']}"
   end
 
   env


### PR DESCRIPTION
The Cassandra RubyGem and Cassandra itself have different ideas about what `CASSANDRA_HOME` should point to, so if a custom `CASSANDRA_INCLUDE` is specified, assume that it will define `CASSANDRA_HOME` and `CASSANDRA_CONF`.

The gist of this fix is that if you're trying to use a location for Cassandra other than the default `~/cassandra`, the environment variables quickly get you into trouble, since the Gem expects `CASSANDRA_HOME` to point to the directory above the actually Cassandra root (e.g. `~/cassandra`), and Cassandra expects it to point to the root (e.g. `~/cassandra/cassandra-0.8`).

The intention of this fix is to assume that if you're using a custom `CASSANRA_INCLUDE` file, that you know that you need to define `CASSANDRA_HOME` and `CASSANDRA_CONF` yourself. This allows you to have a `CASSANDRA_HOME` defined for `cassandra_helper` to use, while still allowing that value to be overridden by the `CASSANRA_INCLUDE` file.

There may well be a better way to resolve this, but this seem like it might cause the least friction. I'm surprised others haven't run into this before, which very well may be a good indication that I'm fundamentally confused about some aspect of how these pieces are supposed to fit together.

In effect, though, what I believe should happen is that the `Rakefile` should give the include file a chance to override the currently set environment variables. Alternatively, if using a `cassandra.in.sh` file other than the one that ships with Cassandra, removing the conditional checks for the presence of those environment variables would work, too, and this may be preferable to making the change here.

Either way, it seems to me that the issue of the discrepancy between what the Gem is expecting `CASSANDRA_HOME` to point to and what Cassandra is expecting should be addressed.

Sorry for the rambling, but my hope is that this request will open up a discussion about what I see as a potential point of confusion.
