### PR TITLE
Support for timestamps in Cassandra::Mock

### DIFF
--- a/test/cassandra_mock_test.rb
+++ b/test/cassandra_mock_test.rb
@@ -94,4 +94,23 @@ class CassandraMockTest < CassandraTest
       @twitter.insert(:UserRelationships, 'a', ['u1','u2'])
     }
   end
+  
+  def test_column_timestamps
+    base_time = Time.now
+    @twitter.insert(:Statuses, "time-key", { "body" => "value" })
+
+    results = @twitter.get(:Statuses, "time-key")
+    assert(results.timestamps["body"] / 1000000 >= base_time.to_i)
+  end
+  
+  def test_supercolumn_timestamps
+    base_time = Time.now
+    @twitter.insert(:StatusRelationships, "time-key", { "super" => { @uuids[1] => "value" }})
+
+    results = @twitter.get(:StatusRelationships, "time-key")
+    assert_nil(results.timestamps["super"])
+    
+    columns = results["super"]
+    assert(columns.timestamps[@uuids[1]] / 1000000 >= base_time.to_i)
+  end
 end

--- a/test/cassandra_test.rb
+++ b/test/cassandra_test.rb
@@ -835,6 +835,25 @@ class CassandraTest < Test::Unit::TestCase
       assert_equal(2, @twitter.get(:UserCounterAggregates, 'bob', 'DAU', 'tomorrow'))
     end
   end
+  
+  def test_column_timestamps
+    base_time = Time.now
+    @twitter.insert(:Statuses, "time-key", { "body" => "value" })
+
+    results = @twitter.get(:Statuses, "time-key")
+    assert(results.timestamps["body"] / 1000000 >= base_time.to_i)
+  end
+  
+  def test_supercolumn_timestamps
+    base_time = Time.now
+    @twitter.insert(:StatusRelationships, "time-key", { "super" => { @uuids[1] => "value" }})
+
+    results = @twitter.get(:StatusRelationships, "time-key")
+    assert_nil(results.timestamps["super"])
+    
+    columns = results["super"]
+    assert(columns.timestamps[@uuids[1]] / 1000000 >= base_time.to_i)
+  end
 
   private
 


### PR DESCRIPTION
The mock was not supporting timestamps in the returned `OrderedHash` instances.
It should now be working (at least, `get` calls do and the tests are all passing).
