### PR TITLE
Unlock dependency for usage gem thrift_client-0.8.1

### DIFF
--- a/lib/cassandra.rb
+++ b/lib/cassandra.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-gem 'thrift_client', '~> 0.7.0'
+gem 'thrift_client', '>= 0.7.0', '< 0.9'
 require 'thrift_client'
 gem 'simple_uuid' , '~> 0.2.0'
 require 'simple_uuid'


### PR DESCRIPTION
To update thrift gem dependency to 0.8.0 we need to add one extra fix to <code>cassandra</code> gem.

We want to use <code>cassandra</code> gem with <code>thrift_client-0.8.1</code> and  <code>thrift-0.8.0</code>. But we can't do this for the reason of locking <code>thrift_client (~> 0.7.0)</code> to use exactly the <code>0.7.x</code> versions.

As you can see, bundler can't activate correct version of <code>thrift_client</code>, every time we try to launch it:

<p>
/home/vagrant/.rvm/gems/ruby-1.9.3-p0@global/gems/bundler-1.0.22/lib/bundler/rubygems_integration.rb:153 :in 'block in replace_gem': <b>can't activate thrift_client (~> 0.7.0), already activated thrift_client-0.8.1</b>. Make sure all dependencies are added to Gemfile. (Gem::LoadError)
<br/>from /home/vagrant/.rvm/gems/ruby-1.9.3-p0@rnds/bundler/gems/cassandra-32b7dfd81a4b/lib/cassandra.rb:2 :in '<top (required)>'
<br/>...
</p>

This patch unlocks usage of gem <code>thirft-0.8.0</code> and gem <code>thrift_client-0.8.1</code>.

Please take a look.
