### PR TITLE
Batch updates for counters

### DIFF
--- a/lib/cassandra/0.8/cassandra.rb
+++ b/lib/cassandra/0.8/cassandra.rb
@@ -5,6 +5,21 @@ class Cassandra
   # Add a value to the counter in cf:key:super column:column
   def add(column_family, key, value, *columns_and_options)
     column_family, column, sub_column, options = extract_and_validate_params(column_family, key, columns_and_options, WRITE_DEFAULTS)
-    _add(column_family, key, column, sub_column, value, options[:consistency])
+
+    mutation_map = if is_super(column_family)
+      {
+        key => {
+          column_family => [_super_counter_mutation(column_family, column, sub_column, value)]
+        }
+      }
+    else
+      {
+        key => {
+          column_family => [_standard_counter_mutation(column_family, column, value)]
+        }
+      }
+    end
+
+    @batch ? @batch << [mutation_map, options[:consistency]] : _mutate(mutation_map, options[:consistency])
   end
 end

--- a/lib/cassandra/0.8/columns.rb
+++ b/lib/cassandra/0.8/columns.rb
@@ -1,4 +1,28 @@
 class Cassandra
   module Columns #:nodoc:
+    def _standard_counter_mutation(column_family, column_name, value)
+      CassandraThrift::Mutation.new(
+        :column_or_supercolumn => CassandraThrift::ColumnOrSuperColumn.new(
+          :counter_column => CassandraThrift::CounterColumn.new(
+            :name      => column_name_class(column_family).new(column_name).to_s,
+            :value     => value,
+          )
+        )
+      )
+    end
+
+    def _super_counter_mutation(column_family, super_column_name, sub_column, value)
+      CassandraThrift::Mutation.new(:column_or_supercolumn =>
+        CassandraThrift::ColumnOrSuperColumn.new(
+          :counter_super_column => CassandraThrift::SuperColumn.new(
+            :name => column_name_class(column_family).new(super_column_name).to_s,
+            :columns => [CassandraThrift::CounterColumn.new(
+              :name      => sub_column_name_class(column_family).new(sub_column).to_s,
+              :value     => value
+            )]
+          )
+        )
+      )
+    end
   end
 end

--- a/lib/cassandra/0.8/protocol.rb
+++ b/lib/cassandra/0.8/protocol.rb
@@ -6,16 +6,5 @@ class Cassandra
     def _remove_counter(key, column_path, consistency_level)
       client.remove_counter(key, column_path, consistency_level)
     end
-
-    def _add(column_family, key, column, sub_column, value, consistency)
-      if is_super(column_family)
-        column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family, :super_column => column)
-        counter_column = CassandraThrift::CounterColumn.new(:name => sub_column, :value => value)
-      else
-        column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family)
-        counter_column = CassandraThrift::CounterColumn.new(:name => column, :value => value)
-      end
-      client.add(key, column_parent, counter_column, consistency)
-    end
   end
 end

--- a/lib/cassandra/1.0/cassandra.rb
+++ b/lib/cassandra/1.0/cassandra.rb
@@ -5,6 +5,21 @@ class Cassandra
   # Add a value to the counter in cf:key:super column:column
   def add(column_family, key, value, *columns_and_options)
     column_family, column, sub_column, options = extract_and_validate_params(column_family, key, columns_and_options, WRITE_DEFAULTS)
-    _add(column_family, key, column, sub_column, value, options[:consistency])
+
+    mutation_map = if is_super(column_family)
+      {
+        key => {
+          column_family => [_super_counter_mutation(column_family, column, sub_column, value)]
+        }
+      }
+    else
+      {
+        key => {
+          column_family => [_standard_counter_mutation(column_family, column, value)]
+        }
+      }
+    end
+
+    @batch ? @batch << [mutation_map, options[:consistency]] : _mutate(mutation_map, options[:consistency])
   end
 end

--- a/lib/cassandra/1.0/columns.rb
+++ b/lib/cassandra/1.0/columns.rb
@@ -1,4 +1,28 @@
 class Cassandra
   module Columns #:nodoc:
+    def _standard_counter_mutation(column_family, column_name, value)
+      CassandraThrift::Mutation.new(
+        :column_or_supercolumn => CassandraThrift::ColumnOrSuperColumn.new(
+          :counter_column => CassandraThrift::CounterColumn.new(
+            :name      => column_name_class(column_family).new(column_name).to_s,
+            :value     => value,
+          )
+        )
+      )
+    end
+
+    def _super_counter_mutation(column_family, super_column_name, sub_column, value)
+      CassandraThrift::Mutation.new(:column_or_supercolumn =>
+        CassandraThrift::ColumnOrSuperColumn.new(
+          :counter_super_column => CassandraThrift::SuperColumn.new(
+            :name => column_name_class(column_family).new(super_column_name).to_s,
+            :columns => [CassandraThrift::CounterColumn.new(
+              :name      => sub_column_name_class(column_family).new(sub_column).to_s,
+              :value     => value
+            )]
+          )
+        )
+      )
+    end
   end
 end

--- a/lib/cassandra/1.0/protocol.rb
+++ b/lib/cassandra/1.0/protocol.rb
@@ -8,16 +8,5 @@ class Cassandra
     def _remove_counter(key, column_path, consistency_level)
       client.remove_counter(key, column_path, consistency_level)
     end
-
-    def _add(column_family, key, column, sub_column, value, consistency)
-      if is_super(column_family)
-        column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family, :super_column => column)
-        counter_column = CassandraThrift::CounterColumn.new(:name => sub_column, :value => value)
-      else
-        column_parent = CassandraThrift::ColumnParent.new(:column_family => column_family)
-        counter_column = CassandraThrift::CounterColumn.new(:name => column, :value => value)
-      end
-      client.add(key, column_parent, counter_column, consistency)
-    end
   end
 end


### PR DESCRIPTION
Runs counter updates through the mutate API instead of the dedicated counter API, and batches them if desired.  
