### PR TITLE
Quick little patch to add echoe as a development dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ unless ENV['FROM_BIN_CASSANDRA_HELPER']
     p.summary = "A Ruby client for the Cassandra distributed database."
     p.rubygems_version = ">= 0.8"
     p.dependencies = ['thrift_client >=0.7.0 <0.9', 'json', 'rake', 'simple_uuid ~>0.2.0']
+    p.development_dependencies = ['echoe']
     p.ignore_pattern = /^(data|vendor\/cassandra|cassandra|vendor\/thrift|.*\.rbc)/
     p.rdoc_pattern = /^(lib|bin|tasks|ext)|^README|^CHANGELOG|^TODO|^LICENSE|^COPYING$/
     p.retain_gemspec = true


### PR DESCRIPTION
Running `rake` without echoe will fail, naturally, if you do not have echoe installed. Echoe should be a dependency in the gemspec, even if it's only a development dependency.

I did not regenerate the .gemspec, I figured that happens on a new version release.
