### PR TITLE
Batch queue size

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,27 @@ Example:
 
     @client.get_indexed_slices(:Statuses, expressions).length       # returns 5
 
+### batch
+Takes a block where all the mutations (inserts and deletions) inside it are 
+queued, and at the end of the block are passed to cassandra in a single batch.
+
+If you don't want to send all the mutations inside the block in a big single 
+batch, you can use the :queue\_size option to send smaller batches. If the 
+queue is not empty at the end of the block, the remaining mutations are sent.
+
+* options
+  * :consistency  - Override the consistency level from individual mutations.
+  * :queue\_size  - Maximum number of mutations to send at once.
+
+Example: 
+
+  @client.batch do 
+    @client.insert(:Statuses, 'k1', {'body' => 'v1'})
+    @client.insert(:Statuses, 'k2', {'body' => 'v2'})
+    @client.remove(:Statuses, 'k3')
+  end
+
+
 ## Reporting Problems
 
 The Github issue tracker is [here](http://github.com/twitter/cassandra/issues). If you have problems with this library or Cassandra itself, please use the [cassandra-user mailing list](http://mail-archives.apache.org/mod_mbox/incubator-cassandra-user/).

--- a/README.md
+++ b/README.md
@@ -361,11 +361,11 @@ queue is not empty at the end of the block, the remaining mutations are sent.
 
 Example: 
 
-  @client.batch do 
-    @client.insert(:Statuses, 'k1', {'body' => 'v1'})
-    @client.insert(:Statuses, 'k2', {'body' => 'v2'})
-    @client.remove(:Statuses, 'k3')
-  end
+    @client.batch do 
+      @client.insert(:Statuses, 'k1', {'body' => 'v1'})
+      @client.insert(:Statuses, 'k2', {'body' => 'v2'})
+      @client.remove(:Statuses, 'k3')
+    end
 
 
 ## Reporting Problems

--- a/lib/cassandra.rb
+++ b/lib/cassandra.rb
@@ -28,6 +28,7 @@ require 'cassandra/dynamic_composite'
 require 'cassandra/ordered_hash'
 require 'cassandra/columns'
 require 'cassandra/protocol'
+require 'cassandra/batch'
 require "cassandra/#{Cassandra.VERSION}/columns"
 require "cassandra/#{Cassandra.VERSION}/protocol"
 require "cassandra/cassandra"

--- a/lib/cassandra/batch.rb
+++ b/lib/cassandra/batch.rb
@@ -1,0 +1,41 @@
+class Cassandra
+  class Batch
+    include Enumerable
+
+    def initialize(cassandra, options) 
+      @queue_size = options.delete(:queue_size) || 0
+      @cassandra = cassandra
+      @options = options
+      @batch_queue = []
+    end
+
+    ##
+    # Append mutation to the batch queue
+    # Flush the batch queue if full
+    #
+    def <<(mutation)
+      @batch_queue << mutation
+      if @queue_size > 0 and @batch_queue.length >= @queue_size
+        begin
+          @cassandra.flush_batch(@options)
+        ensure
+          @batch_queue = []
+        end
+      end
+    end
+
+    ##
+    # Implement each method (required by Enumerable)
+    #
+    def each(&block)
+      @batch_queue.each(&block)
+    end
+
+    ##
+    # Queue size
+    #
+    def length
+      @batch_queue.length
+    end
+  end
+end

--- a/lib/cassandra/mock.rb
+++ b/lib/cassandra/mock.rb
@@ -74,16 +74,21 @@ class Cassandra
       end
     end
 
-    def batch
-      @batch = []
+    def batch(options={})
+      @batch = Cassandra::Batch.new(self, options)
       yield
+      flush_batch(options)
+    ensure
+      @batch = nil
+    end
+
+    def flush_batch(options)
       b = @batch
       @batch = nil
       b.each do |mutation|
         send(*mutation)
       end
-    ensure
-      @batch = nil
+      @batch = b
     end
 
     def get(column_family, key, *columns_and_options)


### PR DESCRIPTION
Hi! I have added the option :queue_size for the bash method. If this option is set it will "flush" the batch every time it gets full. This is handy if you want to send the batch to the server in smaller "pieces". I got the inspiration from the Pycassa library, which has a similar option for the batch method.
