### PR TITLE
Add Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 1.8.7
+env:
+  - CASSANDRA_VERSION=1.1
+  - CASSANDRA_VERSION=1.0
+  - CASSANDRA_VERSION=0.8
+  # these two requires Java 6, see https://github.com/travis-ci/travis-ci/issues/686
+  # - CASSANDRA_VERSION=0.7
+  # - CASSANDRA_VERSION=0.6
+before_script:
+  - java -version
+  - bundle exec rake 'cassandra:start[daemonize]'

--- a/Rakefile
+++ b/Rakefile
@@ -118,7 +118,9 @@ end
 
 desc "Check Java version"
 task :java do
-  unless `java -version 2>&1`.split("\n").first =~ /java version "1.6/ #"
+  is_java16 = `java -version 2>&1`.split("\n").first =~ /java version "1.6/
+
+  if ['0.6', '0.7'].include?(CASSANDRA_VERSION) && !java16
     puts "You need to configure your environment for Java 1.6."
     puts "If you're on OS X, just export the following environment variables:"
     puts '  JAVA_HOME="/System/Library/Frameworks/JavaVM.framework/Versions/1.6/Home"'


### PR DESCRIPTION
This change adds a `.travis.yml` that runs the build for Cassandra 1.1, 1.0 and 0.8 on both 1.8.7 and 1.9.3. Earlier versions that require Java 6 can't be run on Travis until travis-ci/travis-ci#686 is fixed.

I also had to add waiting for Cassandra startup, or the build would fail with intermittent connection failures. After polling for the server to bind, I was able to get [a clean run](https://travis-ci.org/#!/jarib/cassandra/builds/2856376). 

Someone with access to the twitter Github account needs to enable it, either on Travis or in https://github.com/twitter/cassandra/admin/hooks.
