### PR TITLE
Set options for thrift_client in the tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,11 @@ require "#{File.expand_path(File.dirname(__FILE__))}/../lib/cassandra/#{CASSANDR
 begin; require 'ruby-debug'; rescue LoadError; end
 
 begin
-  @test_client = Cassandra.new('Twitter', 'localhost:9160', {:exception_classes => []})
+  @test_client = Cassandra.new('Twitter', 'localhost:9160', :exception_classes => [], :thrift_client_options => {
+    :retries         => 3,
+    :timeout         => 5,
+    :connect_timeout => 1
+  })
 rescue Thrift::TransportException => e
   #FIXME Make server automatically start if not running
   if e.message =~ /Could not connect/

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ require "#{File.expand_path(File.dirname(__FILE__))}/../lib/cassandra/#{CASSANDR
 begin; require 'ruby-debug'; rescue LoadError; end
 
 begin
-  @test_client = Cassandra.new('Twitter', 'localhost:9160', :exception_classes => [], :thrift_client_options => {
+  @test_client = Cassandra.new('Twitter', 'localhost:9160', :thrift_client_options => {
     :retries         => 3,
     :timeout         => 5,
     :connect_timeout => 1


### PR DESCRIPTION
This should take care of the random TransportExceptions we've seen.
