### PR TITLE
OrderedHashInt/OrderedHash returning self for iteration functions

### DIFF
--- a/lib/cassandra/ordered_hash.rb
+++ b/lib/cassandra/ordered_hash.rb
@@ -83,14 +83,17 @@ class Cassandra
 
       def each_key
         @keys.each { |key| yield key }
+        self
       end
 
       def each_value
         @keys.each { |key| yield self[key]}
+        self
       end
 
       def each
         @keys.each {|key| yield [key, self[key]]}
+        self
       end
 
       alias_method :each_pair, :each

--- a/test/cassandra_test.rb
+++ b/test/cassandra_test.rb
@@ -93,6 +93,13 @@ class CassandraTest < Test::Unit::TestCase
     assert_not_equal(hash.keys, @twitter.get(:Users, key).keys)
   end
 
+  def test_ordered_hash_iteration_functions_return_values
+    hash = OrderedHash['a', '', 'b', '', 'c', '', 'd', '',]
+    assert_instance_of OrderedHash, hash.each{|_| true}
+    assert_instance_of OrderedHash, hash.each_value{|_| true}
+    assert_instance_of OrderedHash, hash.each_key{|_| true}
+  end
+
   def test_get_first_time_uuid_column
     @blogs.insert(:Blogs, key,
       {@uuids[0] => 'I like this cat', @uuids[1] => 'Buttons is cuter', @uuids[2] => 'I disagree'})


### PR DESCRIPTION
OrderedHashInt implementation of each/each_value/each_key returns a reference to the OrderedHash' instance variable @keys instead of self. It is controversial to the Ruby's native Hash interface and causes failures in a third party libraries.
Example of such behaviour is to feed OrderedHash (as returned to get_indexed_slices) to multi_column_to_hash!, multi_columns_to_hash!, multi_sub_columns_to_hash! function family. All of them would then return an instance of Array instead of OrderedHash.
