### PR TITLE
#188: disabling native extensions for Windows

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,4 +1,4 @@
-if defined?(RUBY_ENGINE) && RUBY_ENGINE =~ /jruby/
+if (defined?(RUBY_ENGINE) && RUBY_ENGINE =~ /jruby/) or ENV['OS'] == "Windows_NT"
   File.open('Makefile', 'w'){|f| f.puts "all:\n\ninstall:\n" }
 else
   require 'mkmf'


### PR DESCRIPTION
Tested this on Linux, installed without issues.

Rebuilt the gem on Windows 7, was able to install without issues as well
