### PR TITLE
Remove hard-coded release date from gemspec

### DIFF
--- a/cassandra.gemspec
+++ b/cassandra.gemspec
@@ -6,7 +6,6 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0.8") if s.respond_to? :required_rubygems_version=
   s.authors = ["Evan Weaver, Ryan King"]
-  s.date = "2012-09-26"
   s.description = "A Ruby client for the Cassandra distributed database."
   s.email = ""
   s.executables = ["cassandra_helper"]


### PR DESCRIPTION
The release date in the gemspec has not been updated since version 0.16.0. As a result, the release date for the last 4 versions appears as September 26, 2012 at http://rubygems.org/gems/cassandra/versions. Specifying a release date is not necessary. If it is missing from the gemspec, it will be set automatically by the rubygems.org server.
