### PR TITLE
Composite methods to explicity create from parts array

### DIFF
--- a/lib/cassandra/composite.rb
+++ b/lib/cassandra/composite.rb
@@ -11,16 +11,13 @@ class Cassandra
       if parts.last.is_a?(Hash)
         options = parts.pop
       end
-      @column_slice = options[:slice]
-      raise ArgumentError if @column_slice != nil && ![:before, :after].include?(@column_slice)
 
       if parts.length == 1 && parts[0].instance_of?(self.class)
-        @column_slice = parts[0].column_slice
-        @parts = parts[0].parts
+        make_from_parts(parts[0].parts, :slice => parts[0].column_slice)
       elsif parts.length == 1 && parts[0].instance_of?(String) && @column_slice.nil? && try_packed_composite(parts[0])
         @hash = parts[0].hash
       else
-        @parts = parts
+        make_from_parts(parts, options)
       end
     end
 

--- a/lib/cassandra/composite.rb
+++ b/lib/cassandra/composite.rb
@@ -30,6 +30,13 @@ class Cassandra
       return obj
     end
 
+    def self.new_from_parts(parts, args={})
+      obj = new
+      obj.make_from_parts(parts, args)
+
+      return obj
+    end
+
     def [](*args)
       return @parts[*args]
     end
@@ -100,6 +107,12 @@ class Cassandra
 
       @column_slice = :after if end_of_component == "\x01"
       @column_slice = :before if end_of_component == "\xFF"
+    end
+
+    def make_from_parts(parts, args)
+      @parts = parts
+      @column_slice = args[:slice]
+      raise ArgumentError if @column_slice != nil && ![:before, :after].include?(@column_slice)
     end
 
     private

--- a/test/cassandra_test.rb
+++ b/test/cassandra_test.rb
@@ -30,7 +30,6 @@ class CassandraTest < Test::Unit::TestCase
       Cassandra::Composite.new([5].pack('N'), "aardvark"),
       Cassandra::Composite.new([1].pack('N'), "elephant"),
       Cassandra::Composite.new([10].pack('N'), "kangaroo"),
-      Cassandra::Composite.new_from_parts([[20].pack('N'), "meerkat"]),
     ]
     @dynamic_composites = [
       Cassandra::DynamicComposite.new(['i', [5].pack('N')], ['UTF8Type', "zebra"]),
@@ -1245,6 +1244,9 @@ class CassandraTest < Test::Unit::TestCase
 
     def test_composite_column_type_conversion
       columns = {}
+      @composites.push(
+        Cassandra::Composite.new_from_parts([[20].pack('N'), "meerkat"]),
+      )
       @composites.each_with_index do |c, index|
         columns[c] = "value-#{index}"
       end

--- a/test/cassandra_test.rb
+++ b/test/cassandra_test.rb
@@ -30,7 +30,7 @@ class CassandraTest < Test::Unit::TestCase
       Cassandra::Composite.new([5].pack('N'), "aardvark"),
       Cassandra::Composite.new([1].pack('N'), "elephant"),
       Cassandra::Composite.new([10].pack('N'), "kangaroo"),
-      Cassandra::Composite.new([20].pack('N'), "meerkat"),
+      Cassandra::Composite.new_from_parts([[20].pack('N'), "meerkat"]),
     ]
     @dynamic_composites = [
       Cassandra::DynamicComposite.new(['i', [5].pack('N')], ['UTF8Type', "zebra"]),
@@ -1273,7 +1273,7 @@ class CassandraTest < Test::Unit::TestCase
       column_slice = @type_conversions.get(:CompositeColumnConversion, key,
         :start => Cassandra::Composite.new([5].pack('N'), :slice => :after).to_s
       ).keys
-      assert_equal([columns_in_order[-2..-1]], column_slice)
+      assert_equal(columns_in_order[-2..-1], column_slice)
 
       column_slice = @type_conversions.get(:CompositeColumnConversion, key,
         :finish => Cassandra::Composite.new([10].pack('N'), :slice => :before).to_s

--- a/test/cassandra_test.rb
+++ b/test/cassandra_test.rb
@@ -30,6 +30,7 @@ class CassandraTest < Test::Unit::TestCase
       Cassandra::Composite.new([5].pack('N'), "aardvark"),
       Cassandra::Composite.new([1].pack('N'), "elephant"),
       Cassandra::Composite.new([10].pack('N'), "kangaroo"),
+      Cassandra::Composite.new([20].pack('N'), "meerkat"),
     ]
     @dynamic_composites = [
       Cassandra::DynamicComposite.new(['i', [5].pack('N')], ['UTF8Type', "zebra"]),
@@ -1253,12 +1254,13 @@ class CassandraTest < Test::Unit::TestCase
         Cassandra::Composite.new([5].pack('N'), "aardvark"),
         Cassandra::Composite.new([5].pack('N'), "zebra"),
         Cassandra::Composite.new([10].pack('N'), "kangaroo"),
+        Cassandra::Composite.new([20].pack('N'), "meerkat"),
       ]
       assert_equal(columns_in_order, @type_conversions.get(:CompositeColumnConversion, key).keys)
 
       column_slice = @type_conversions.get(:CompositeColumnConversion, key,
         :start => Cassandra::Composite.new([1].pack('N')),
-        :finish => Cassandra::Composite.new([10].pack('N'))
+        :finish => Cassandra::Composite.new([20].pack('N'))
       ).keys
       assert_equal(columns_in_order[0..-2], column_slice)
 
@@ -1271,12 +1273,12 @@ class CassandraTest < Test::Unit::TestCase
       column_slice = @type_conversions.get(:CompositeColumnConversion, key,
         :start => Cassandra::Composite.new([5].pack('N'), :slice => :after).to_s
       ).keys
-      assert_equal([columns_in_order[-1]], column_slice)
+      assert_equal([columns_in_order[-2..-1]], column_slice)
 
       column_slice = @type_conversions.get(:CompositeColumnConversion, key,
         :finish => Cassandra::Composite.new([10].pack('N'), :slice => :before).to_s
       ).keys
-      assert_equal(columns_in_order[0..-2], column_slice)
+      assert_equal(columns_in_order[0..-3], column_slice)
 
       assert_equal('value-2', @type_conversions.get(:CompositeColumnConversion, key, columns_in_order.first))
     end

--- a/test/cassandra_test.rb
+++ b/test/cassandra_test.rb
@@ -1245,7 +1245,7 @@ class CassandraTest < Test::Unit::TestCase
     def test_composite_column_type_conversion
       columns = {}
       @composites.push(
-        Cassandra::Composite.new_from_parts([[20].pack('N'), "meerkat"]),
+        Cassandra::Composite.new_from_parts([[20].pack('N'), "meerkat"])
       )
       @composites.each_with_index do |c, index|
         columns[c] = "value-#{index}"

--- a/test/composite_type_test.rb
+++ b/test/composite_type_test.rb
@@ -24,6 +24,11 @@ class CompositeTypesTest < Test::Unit::TestCase
       assert_equal(@col_parts[i], @dycol[i])
       assert_equal(@col_parts[i], @dycol_alias[i])
     end
+
+    col2 = Cassandra::Composite.new_from_parts(@col_parts)
+    (0..2).each do |i|
+      assert_equal(@col_parts[i], col2[i].to_s)
+    end
   end
 
   def test_packing_and_unpacking


### PR DESCRIPTION
Allows new composites to be created without the ambiguity of base initialize.

Composites can be created from an array of parts, followed by the options hash,
similar to the basic initializer, but the new method will not attempt to detect
packed parts as an argument.
